### PR TITLE
Refactor CLI arguments

### DIFF
--- a/src/analysis/callback_duration.rs
+++ b/src/analysis/callback_duration.rs
@@ -149,7 +149,7 @@ impl CallbackDuration {
         durations.sort_unstable();
         let durations_sorted = Sorted::from_sorted(durations).unwrap();
 
-        let duration_quantiles = Args::get()
+        let duration_quantiles = Args::get_analyses_args()
             .quantiles()
             .iter()
             .map(|q| {

--- a/src/analysis/utils.rs
+++ b/src/analysis/utils.rs
@@ -47,7 +47,7 @@ impl std::fmt::Display for DisplayDurationStats<'_> {
 
         let sorted = Sorted::from_unsorted(self.0);
         write!(f, "count={}", sorted.len())?;
-        for q in Args::get().quantiles() {
+        for q in Args::get_analyses_args().quantiles() {
             let quantile = *sorted.quantile(*q).unwrap();
             write!(f, "{}{}={}", self.1, q, DurationDisplayImprecise(quantile))?;
         }

--- a/src/argsv2/analysis_args.rs
+++ b/src/argsv2/analysis_args.rs
@@ -1,19 +1,8 @@
-use std::borrow::Cow;
-use std::ffi::{CStr, CString};
-use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::{borrow::Cow, ffi::CString, path::{Path, PathBuf}};
 
-use bt2_sys::graph::component::BtComponentType;
-use bt2_sys::query::support_info;
-use clap::builder::ArgPredicate;
-use clap::{Parser, ValueHint};
-use clap_verbosity_flag::{Verbosity, WarnLevel};
-use color_eyre::eyre::ensure;
-use walkdir::WalkDir;
+use clap::{Parser, ValueHint, builder::ArgPredicate};
 
 use crate::statistics::Quantile;
-
-pub static CLI_ARGS: OnceLock<Args> = OnceLock::new();
 
 mod filenames {
     pub const DEPENDENCY_GRAPH: &str = "dependency_graph.dot";
@@ -29,7 +18,7 @@ mod filenames {
 
 #[derive(Debug, Clone, Parser)]
 #[allow(clippy::struct_excessive_bools)]
-pub struct Args {
+pub struct AnalysisArgs {
     /// Run all analyses with their default output filenames
     ///
     /// The output `filename` can be changed by specific analysis option.
@@ -137,19 +126,12 @@ pub struct Args {
     #[arg(value_parser, num_args = 1.., required = true, value_hint = ValueHint::DirPath)]
     trace_paths: Vec<PathBuf>,
 
-    #[command(flatten)]
-    pub verbose: Verbosity<WarnLevel>,
-
     /// Only the directories specified by `TRACE_PATHS` are searched for traces, not their subdirectories.
     #[arg(long)]
     exact_trace_path: bool,
 }
 
-impl Args {
-    pub fn get() -> &'static Args {
-        CLI_ARGS.get_or_init(Self::parse)
-    }
-
+impl AnalysisArgs {
     pub fn trace_paths(&self) -> &[PathBuf] {
         &self.trace_paths
     }
@@ -286,112 +268,18 @@ impl Args {
     }
 }
 
-// Valid trace path should have a weight set to 0.75 so we set the threshold slightly lower.
-const TRACE_PATH_LIKELIHOOD_THRESHOLD: f64 = 0.74;
-
-pub fn is_trace_path(path: &CStr) -> bool {
-    let support_info_query =
-        support_info::Query::new_prepared("ctf", "fs", BtComponentType::Source)
-            .expect("Failed to prepare support info query");
-
-    let path_cstr = CString::new(path.to_str().unwrap()).unwrap();
-
-    let result = support_info_query
-        .query(bt2_sys::query::SupportInfoParams::Directory(&path_cstr))
-        .expect("Failed to query support info");
-
-    result.weight() > TRACE_PATH_LIKELIHOOD_THRESHOLD
-}
-
-pub fn find_trace_paths(search_path: &Path) -> Vec<CString> {
-    let support_info_query =
-        support_info::Query::new_prepared("ctf", "fs", BtComponentType::Source)
-            .expect("Failed to prepare support info query");
-
-    let mut trace_paths = Vec::new();
-    for dir in WalkDir::new(search_path)
-        .into_iter()
-        .filter_entry(|e| e.file_type().is_dir())
-    {
-        let dir = dir.expect("Failed to read directory");
-        let path = dir.path();
-        let path_cstr = CString::new(path.to_str().unwrap()).unwrap();
-
-        let result = support_info_query
-            .query(bt2_sys::query::SupportInfoParams::Directory(&path_cstr))
-            .expect("Failed to query support info");
-
-        if result.weight() > TRACE_PATH_LIKELIHOOD_THRESHOLD {
-            trace_paths.push(path_cstr);
-        }
-    }
-
-    trace_paths
-}
-
-pub fn prepare_trace_paths() -> color_eyre::Result<Vec<CString>> {
-    let trace_paths: Vec<_> = if Args::get().is_exact_path() {
-        Args::get()
-            .trace_paths_cstring()
-            .into_iter()
-            .filter_map(|path| {
-                if is_trace_path(&path) {
-                    Some(path)
-                } else {
-                    None
-                }
-            })
-            .collect()
-    } else {
-        Args::get()
-            .trace_paths()
-            .iter()
-            .map(AsRef::as_ref)
-            .flat_map(find_trace_paths)
-            .collect()
-    };
-
-    ensure!(
-        !trace_paths.is_empty(),
-        "No traces found in the provided paths."
-    );
-
-    println!("Found traces:");
-    for path in &trace_paths {
-        println!("  {}", path.to_string_lossy());
-    }
-
-    Ok(trace_paths)
-}
-
 #[cfg(test)]
 mod test {
-    use clap::{CommandFactory, Parser};
-    use std::path::Path;
+    use std::{borrow::Cow, path::{Path, PathBuf}};
 
-    use super::*;
+    use clap::Parser;
 
-    #[test]
-    #[ignore]
-    fn print_help() {
-        Args::command().print_help().unwrap();
-    }
+    use crate::argsv2::{Args, analysis_args::filenames};
 
-    #[test]
-    #[ignore]
-    fn print_long_help() {
-        Args::command().print_long_help().unwrap();
-    }
-
-    #[test]
-    fn verify_cli() {
-        Args::command().debug_assert();
-    }
-
-    #[test]
     fn test_basic_args_parsing() {
         let args = Args::try_parse_from(["program", "/tmp/trace"])
-            .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"));
+            .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
+            .as_analysis_args();
 
         assert_eq!(args.trace_paths.len(), 1);
         assert_eq!(args.trace_paths[0], PathBuf::from("/tmp/trace"));
@@ -403,7 +291,8 @@ mod test {
     #[test]
     fn test_multiple_trace_paths() {
         let args = Args::try_parse_from(["program", "/tmp/trace1", "/tmp/trace2"])
-            .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"));
+            .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
+            .as_analysis_args();
 
         assert_eq!(args.trace_paths.len(), 2);
         assert_eq!(args.trace_paths[0], PathBuf::from("/tmp/trace1"));
@@ -413,7 +302,8 @@ mod test {
     #[test]
     fn test_exact_trace_path_flag() {
         let args = Args::try_parse_from(["program", "--exact-trace-path", "/tmp/trace"])
-            .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"));
+            .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
+            .as_analysis_args();
 
         assert!(args.exact_trace_path);
         assert!(args.is_exact_path());
@@ -427,7 +317,8 @@ mod test {
         }
 
         let args = Args::try_parse_from(["program", "-o", "/tmp", "/tmp/trace"])
-            .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"));
+            .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
+            .as_analysis_args();
 
         assert_eq!(args.out_dir, Some(PathBuf::from("/tmp")));
     }
@@ -436,7 +327,8 @@ mod test {
     fn test_quantiles_parsing() {
         let args =
             Args::try_parse_from(["program", "--quantiles", "0,0.25,0.5,0.75,1", "/tmp/trace"])
-                .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"));
+                .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
+                .as_analysis_args();
 
         assert_eq!(args.quantiles.len(), 5);
         assert_eq!(args.quantiles[0], 0.0.try_into().unwrap());
@@ -460,7 +352,8 @@ mod test {
             "--message-latency=custom_latency.json",
             "/tmp/trace",
         ])
-        .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"));
+        .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
+        .as_analysis_args();
 
         assert!(!args.all); // Should be automatically set to false when any analysis flag is used
         assert_eq!(
@@ -513,7 +406,8 @@ mod test {
             "--message-latency=custom_latency.json",
             "/tmp/trace",
         ])
-        .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"));
+        .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
+        .as_analysis_args();
 
         assert!(args.all);
         assert_eq!(
@@ -533,7 +427,8 @@ mod test {
     #[test]
     fn test_implicit_all_flag() {
         let args = Args::try_parse_from(["program", "/tmp/trace"])
-            .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"));
+            .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
+            .as_analysis_args();
 
         assert!(args.all);
         assert_eq!(
@@ -562,7 +457,8 @@ mod test {
             "--callback-duration=/callback.json",
             "/tmp/trace",
         ])
-        .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"));
+        .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
+        .as_analysis_args();
 
         assert_eq!(
             args.dependency_graph_path(),

--- a/src/argsv2/analysis_args.rs
+++ b/src/argsv2/analysis_args.rs
@@ -276,10 +276,11 @@ mod test {
 
     use crate::argsv2::{Args, analysis_args::filenames};
 
+    #[test]
     fn test_basic_args_parsing() {
-        let args = Args::try_parse_from(["program", "/tmp/trace"])
+        let args = Args::try_parse_from(["program", "analyze", "/tmp/trace"])
             .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
-            .as_analysis_args();
+            .into_analysis_args();
 
         assert_eq!(args.trace_paths.len(), 1);
         assert_eq!(args.trace_paths[0], PathBuf::from("/tmp/trace"));
@@ -290,9 +291,9 @@ mod test {
 
     #[test]
     fn test_multiple_trace_paths() {
-        let args = Args::try_parse_from(["program", "/tmp/trace1", "/tmp/trace2"])
+        let args = Args::try_parse_from(["program", "analyze", "/tmp/trace1", "/tmp/trace2"])
             .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
-            .as_analysis_args();
+            .into_analysis_args();
 
         assert_eq!(args.trace_paths.len(), 2);
         assert_eq!(args.trace_paths[0], PathBuf::from("/tmp/trace1"));
@@ -301,9 +302,9 @@ mod test {
 
     #[test]
     fn test_exact_trace_path_flag() {
-        let args = Args::try_parse_from(["program", "--exact-trace-path", "/tmp/trace"])
+        let args = Args::try_parse_from(["program", "analyze", "--exact-trace-path", "/tmp/trace"])
             .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
-            .as_analysis_args();
+            .into_analysis_args();
 
         assert!(args.exact_trace_path);
         assert!(args.is_exact_path());
@@ -316,9 +317,9 @@ mod test {
             return;
         }
 
-        let args = Args::try_parse_from(["program", "-o", "/tmp", "/tmp/trace"])
+        let args = Args::try_parse_from(["program", "analyze", "-o", "/tmp", "/tmp/trace"])
             .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
-            .as_analysis_args();
+            .into_analysis_args();
 
         assert_eq!(args.out_dir, Some(PathBuf::from("/tmp")));
     }
@@ -326,9 +327,9 @@ mod test {
     #[test]
     fn test_quantiles_parsing() {
         let args =
-            Args::try_parse_from(["program", "--quantiles", "0,0.25,0.5,0.75,1", "/tmp/trace"])
+            Args::try_parse_from(["program", "analyze", "--quantiles", "0,0.25,0.5,0.75,1", "/tmp/trace"])
                 .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
-                .as_analysis_args();
+                .into_analysis_args();
 
         assert_eq!(args.quantiles.len(), 5);
         assert_eq!(args.quantiles[0], 0.0.try_into().unwrap());
@@ -340,7 +341,7 @@ mod test {
 
     #[test]
     fn test_all_analysis_disabled() {
-        let args = Args::try_parse_from(["program", "--all=false", "/tmp/trace"]);
+        let args = Args::try_parse_from(["program", "analyze", "--all=false", "/tmp/trace"]);
         assert!(args.is_err(), "Disabling all analyses should be rejected");
     }
 
@@ -348,12 +349,13 @@ mod test {
     fn test_specific_analysis_flags() {
         let args = Args::try_parse_from([
             "program",
+            "analyze",
             "--dependency-graph",
             "--message-latency=custom_latency.json",
             "/tmp/trace",
         ])
         .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
-        .as_analysis_args();
+        .into_analysis_args();
 
         assert!(!args.all); // Should be automatically set to false when any analysis flag is used
         assert_eq!(
@@ -369,7 +371,7 @@ mod test {
 
     #[test]
     fn test_empty_quantiles_rejected() {
-        let result = Args::try_parse_from(["program", "--quantiles", "", "/tmp/trace"]);
+        let result = Args::try_parse_from(["program", "analyze", "--quantiles", "", "/tmp/trace"]);
         assert!(result.is_err(), "Empty quantiles list should be rejected");
 
         let err = result.unwrap_err();
@@ -382,7 +384,7 @@ mod test {
     #[test]
     fn test_space_separated_quantiles_rejected() {
         // Space is a value terminator according to the quantiles arg definition
-        let result = Args::try_parse_from(["program", "--quantiles", "0.1 0.5 0.9", "/tmp/trace"]);
+        let result = Args::try_parse_from(["program", "analyze", "--quantiles", "0.1 0.5 0.9", "/tmp/trace"]);
 
         // This should not work due to terminator behavior
         assert!(
@@ -401,13 +403,14 @@ mod test {
     fn test_all_and_specific_analysis_flags() {
         let args = Args::try_parse_from([
             "program",
+            "analyze",
             "--all",
             "--dependency-graph",
             "--message-latency=custom_latency.json",
             "/tmp/trace",
         ])
         .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
-        .as_analysis_args();
+        .into_analysis_args();
 
         assert!(args.all);
         assert_eq!(
@@ -426,9 +429,9 @@ mod test {
 
     #[test]
     fn test_implicit_all_flag() {
-        let args = Args::try_parse_from(["program", "/tmp/trace"])
+        let args = Args::try_parse_from(["program", "analyze", "/tmp/trace"])
             .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
-            .as_analysis_args();
+            .into_analysis_args();
 
         assert!(args.all);
         assert_eq!(
@@ -449,6 +452,7 @@ mod test {
     fn test_path_concatenation() {
         let args = Args::try_parse_from([
             "program",
+            "analyze",
             "-o",
             "/tmp",
             "--all",
@@ -458,7 +462,7 @@ mod test {
             "/tmp/trace",
         ])
         .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
-        .as_analysis_args();
+        .into_analysis_args();
 
         assert_eq!(
             args.dependency_graph_path(),

--- a/src/argsv2/analysis_args.rs
+++ b/src/argsv2/analysis_args.rs
@@ -1,6 +1,9 @@
-use std::{borrow::Cow, ffi::CString, path::{Path, PathBuf}};
+use std::borrow::Cow;
+use std::ffi::CString;
+use std::path::{Path, PathBuf};
 
-use clap::{Parser, ValueHint, builder::ArgPredicate};
+use clap::builder::ArgPredicate;
+use clap::{Parser, ValueHint};
 
 use crate::statistics::Quantile;
 
@@ -270,11 +273,13 @@ impl AnalysisArgs {
 
 #[cfg(test)]
 mod test {
-    use std::{borrow::Cow, path::{Path, PathBuf}};
+    use std::borrow::Cow;
+    use std::path::{Path, PathBuf};
 
     use clap::Parser;
 
-    use crate::argsv2::{Args, analysis_args::filenames};
+    use crate::argsv2::analysis_args::filenames;
+    use crate::argsv2::Args;
 
     #[test]
     fn test_basic_args_parsing() {
@@ -326,10 +331,15 @@ mod test {
 
     #[test]
     fn test_quantiles_parsing() {
-        let args =
-            Args::try_parse_from(["program", "analyze", "--quantiles", "0,0.25,0.5,0.75,1", "/tmp/trace"])
-                .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
-                .into_analysis_args();
+        let args = Args::try_parse_from([
+            "program",
+            "analyze",
+            "--quantiles",
+            "0,0.25,0.5,0.75,1",
+            "/tmp/trace",
+        ])
+        .unwrap_or_else(|e| panic!("Failed to parse arguments: {e}"))
+        .into_analysis_args();
 
         assert_eq!(args.quantiles.len(), 5);
         assert_eq!(args.quantiles[0], 0.0.try_into().unwrap());
@@ -384,7 +394,13 @@ mod test {
     #[test]
     fn test_space_separated_quantiles_rejected() {
         // Space is a value terminator according to the quantiles arg definition
-        let result = Args::try_parse_from(["program", "analyze", "--quantiles", "0.1 0.5 0.9", "/tmp/trace"]);
+        let result = Args::try_parse_from([
+            "program",
+            "analyze",
+            "--quantiles",
+            "0.1 0.5 0.9",
+            "/tmp/trace",
+        ]);
 
         // This should not work due to terminator behavior
         assert!(

--- a/src/argsv2/chart_args.rs
+++ b/src/argsv2/chart_args.rs
@@ -18,9 +18,9 @@ pub struct ChartArgs {
     #[clap(long, short = 'o', value_name = "OUTPUT", value_hint = ValueHint::AnyPath)]
     output_path: Option<PathBuf>,
 
-    /// Whether the chart should be render from scratch
+    /// Indicates whether the chart should be rendered from scratch.
     ///
-    /// If not, set a preexisting chart will be used only if it matches all parameters.
+    /// If not set, an existing chart will be reused only if it matches all specified parameters.
     #[clap(long, short = 'c', default_value = "false")]
     clean: bool,
 
@@ -61,7 +61,10 @@ pub struct ChartRequest {
     #[command(subcommand)]
     pub plot: ChartVariants,
 
-    /// The size of the rendered image
+    /// The rectangular size of the rendered image in pixels
+    ///
+    /// - For PNG this directly translates to pixels
+    /// - For SVG this is the size in pixels with scale 1.0
     #[clap(long, default_value = "800")]
     pub size: u32,
 

--- a/src/argsv2/chart_args.rs
+++ b/src/argsv2/chart_args.rs
@@ -1,10 +1,10 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use clap::{Args, Subcommand, ValueEnum, ValueHint};
 use derive_more::Display;
 
 #[derive(Debug, Clone, Args)]
 pub struct ChartArgs {
-    /// Full name of the node to raw the chart for
+    /// Full name of the node to draw the chart for
     ///
     /// The name should include the namespace and node's name
     #[clap(long, short = 'n')]
@@ -18,9 +18,9 @@ pub struct ChartArgs {
     #[clap(long, short = 'o', value_name = "OUTPUT", value_hint = ValueHint::AnyPath)]
     output_path: Option<PathBuf>,
 
-    /// Whether the chart should be rerender from scratch
+    /// Whether the chart should be render from scratch
     ///
-    /// if not set a preexisting chart will be used only if it matches all parameters
+    /// If not, set a preexisting chart will be used only if it matches all parameters.
     #[clap(long, short = 'c', default_value = "false")]
     clean: bool,
 
@@ -33,12 +33,12 @@ impl ChartArgs {
         &self.node
     }
 
-    pub fn input_path(&self) -> &Option<PathBuf> {
-        &self.input_path
+    pub fn input_path(&self) -> Option<&Path> {
+        self.input_path.as_deref()
     }
 
-    pub fn output_path(&self) -> &Option<PathBuf> {
-        &self.output_path
+    pub fn output_path(&self) -> Option<&Path> {
+        self.output_path.as_deref()
     }
 
     pub fn clean(&self) -> bool {
@@ -70,7 +70,7 @@ pub struct ChartRequest {
     pub output_format: ChartOutputFormat
 }
 
-#[derive(Debug, Display, ValueEnum, Clone, Default)]
+#[derive(Debug, Display, ValueEnum, Clone, Copy, Default)]
 pub enum ChartOutputFormat {
     #[default]
     #[display("svg")]
@@ -79,7 +79,7 @@ pub enum ChartOutputFormat {
     PNG
 }
 
-#[derive(Debug, Display, ValueEnum, Clone)]
+#[derive(Debug, Display, ValueEnum, Clone, Copy)]
 pub enum ChartedValue {
     /// Callback execution durations
     #[display("Callback execution time")]
@@ -101,7 +101,7 @@ pub enum ChartedValue {
     MessagesLatency,
 }
 
-#[derive(Debug, Display, Subcommand, Clone)]
+#[derive(Debug, Display, Subcommand, Clone, Copy)]
 pub enum ChartVariants {
     #[display("Histogram")]
     Histogram(HistogramData),
@@ -109,7 +109,7 @@ pub enum ChartVariants {
     Scatter,
 }
 
-#[derive(Debug, Display, Args, Clone)]
+#[derive(Debug, Display, Args, Clone, Copy)]
 #[display("Histogram data {{ bins: {bins:?} }}")]
 pub struct HistogramData {
     /// Number of bins to split the data into

--- a/src/argsv2/chart_args.rs
+++ b/src/argsv2/chart_args.rs
@@ -1,6 +1,6 @@
-use std::path::{Path, PathBuf};
 use clap::{Args, Subcommand, ValueEnum, ValueHint};
 use derive_more::Display;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Args)]
 pub struct ChartArgs {
@@ -67,7 +67,7 @@ pub struct ChartRequest {
 
     /// The filetype (output format) the rendered image should be in
     #[clap(long, default_value_t = ChartOutputFormat::default())]
-    pub output_format: ChartOutputFormat
+    pub output_format: ChartOutputFormat,
 }
 
 #[derive(Debug, Display, ValueEnum, Clone, Copy, Default)]
@@ -76,7 +76,7 @@ pub enum ChartOutputFormat {
     #[display("svg")]
     SVG,
     #[display("png")]
-    PNG
+    PNG,
 }
 
 #[derive(Debug, Display, ValueEnum, Clone, Copy)]
@@ -114,5 +114,5 @@ pub enum ChartVariants {
 pub struct HistogramData {
     /// Number of bins to split the data into
     #[arg(long, short = 'b', value_name = "BINS")]
-    pub bins: Option<usize>
+    pub bins: Option<usize>,
 }

--- a/src/argsv2/chart_args.rs
+++ b/src/argsv2/chart_args.rs
@@ -1,0 +1,118 @@
+use std::path::PathBuf;
+use clap::{Args, Subcommand, ValueEnum, ValueHint};
+use derive_more::Display;
+
+#[derive(Debug, Clone, Args)]
+pub struct ChartArgs {
+    /// Full name of the node to raw the chart for
+    ///
+    /// The name should include the namespace and node's name
+    #[clap(long, short = 'n')]
+    node: String,
+
+    /// The input path, either a file of the data or a folder containing the default named file with the necessary data
+    #[clap(long, short = 'i', value_name = "INPUT", value_hint = ValueHint::AnyPath)]
+    input_path: Option<PathBuf>,
+
+    /// The output path, either a folder to which the file will be generated or a file to write into
+    #[clap(long, short = 'o', value_name = "OUTPUT", value_hint = ValueHint::AnyPath)]
+    output_path: Option<PathBuf>,
+
+    /// Whether the chart should be rerender from scratch
+    ///
+    /// if not set a preexisting chart will be used only if it matches all parameters
+    #[clap(long, short = 'c', default_value = "false")]
+    clean: bool,
+
+    #[clap(flatten)]
+    chart: ChartRequest,
+}
+
+impl ChartArgs {
+    pub fn node(&self) -> &str {
+        &self.node
+    }
+
+    pub fn input_path(&self) -> &Option<PathBuf> {
+        &self.input_path
+    }
+
+    pub fn output_path(&self) -> &Option<PathBuf> {
+        &self.output_path
+    }
+
+    pub fn clean(&self) -> bool {
+        self.clean
+    }
+
+    pub fn chart(&self) -> &ChartRequest {
+        &self.chart
+    }
+}
+
+#[derive(Debug, Display, Args, Clone)]
+#[display("ChartOf {{ value: {value}, {plot} }}")]
+pub struct ChartRequest {
+    /// The value to plot into the chart
+    #[clap(long)]
+    pub value: ChartedValue,
+
+    /// The type of chart to render the data as
+    #[command(subcommand)]
+    pub plot: ChartVariants,
+
+    /// The size of the rendered image
+    #[clap(long, default_value = "800")]
+    pub size: u32,
+
+    /// The filetype (output format) the rendered image should be in
+    #[clap(long, default_value_t = ChartOutputFormat::default())]
+    pub output_format: ChartOutputFormat
+}
+
+#[derive(Debug, Display, ValueEnum, Clone, Default)]
+pub enum ChartOutputFormat {
+    #[default]
+    #[display("svg")]
+    SVG,
+    #[display("png")]
+    PNG
+}
+
+#[derive(Debug, Display, ValueEnum, Clone)]
+pub enum ChartedValue {
+    /// Callback execution durations
+    #[display("Callback execution time")]
+    CallbackDuration,
+    /// Delays between callback or timer activations
+    #[display("Delays between activations")]
+    ActivationsDelay,
+
+    /// Delays between publisher publications
+    #[display("Delay between publication")]
+    PublicationsDelay,
+
+    /// Delays between subscriber messages
+    #[display("Delay between")]
+    MessagesDelay,
+
+    /// Latency of a communication channel
+    #[display("Latency")]
+    MessagesLatency,
+}
+
+#[derive(Debug, Display, Subcommand, Clone)]
+pub enum ChartVariants {
+    #[display("Histogram")]
+    Histogram(HistogramData),
+    #[display("Scatter")]
+    Scatter,
+}
+
+#[derive(Debug, Display, Args, Clone)]
+#[display("Histogram data {{ bins: {bins:?} }}")]
+pub struct HistogramData {
+    /// Number of bins to split the data into
+    #[arg(long, short = 'b', value_name = "BINS")]
+    pub bins: Option<usize>
+}

--- a/src/argsv2/helpers.rs
+++ b/src/argsv2/helpers.rs
@@ -1,0 +1,85 @@
+use std::{ffi::{CStr, CString}, path::Path};
+
+use bt2_sys::{graph::component::BtComponentType, query::support_info};
+use color_eyre::eyre::ensure;
+use walkdir::WalkDir;
+
+use crate::argsv2::Args;
+
+// Valid trace path should have a weight set to 0.75 so we set the threshold slightly lower.
+const TRACE_PATH_LIKELIHOOD_THRESHOLD: f64 = 0.74;
+
+pub fn is_trace_path(path: &CStr) -> bool {
+    let support_info_query =
+        support_info::Query::new_prepared("ctf", "fs", BtComponentType::Source)
+            .expect("Failed to prepare support info query");
+
+    let path_cstr = CString::new(path.to_str().unwrap()).unwrap();
+
+    let result = support_info_query
+        .query(bt2_sys::query::SupportInfoParams::Directory(&path_cstr))
+        .expect("Failed to query support info");
+
+    result.weight() > TRACE_PATH_LIKELIHOOD_THRESHOLD
+}
+
+pub fn find_trace_paths(search_path: &Path) -> Vec<CString> {
+    let support_info_query =
+        support_info::Query::new_prepared("ctf", "fs", BtComponentType::Source)
+            .expect("Failed to prepare support info query");
+
+    let mut trace_paths = Vec::new();
+    for dir in WalkDir::new(search_path)
+        .into_iter()
+        .filter_entry(|e| e.file_type().is_dir())
+    {
+        let dir = dir.expect("Failed to read directory");
+        let path = dir.path();
+        let path_cstr = CString::new(path.to_str().unwrap()).unwrap();
+
+        let result = support_info_query
+            .query(bt2_sys::query::SupportInfoParams::Directory(&path_cstr))
+            .expect("Failed to query support info");
+
+        if result.weight() > TRACE_PATH_LIKELIHOOD_THRESHOLD {
+            trace_paths.push(path_cstr);
+        }
+    }
+
+    trace_paths
+}
+
+pub fn prepare_trace_paths() -> color_eyre::Result<Vec<CString>> {
+    let trace_paths: Vec<_> = if Args::get_analyses_args().is_exact_path() {
+        Args::get_analyses_args()
+            .trace_paths_cstring()
+            .into_iter()
+            .filter_map(|path| {
+                if is_trace_path(&path) {
+                    Some(path)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    } else {
+        Args::get_analyses_args()
+            .trace_paths()
+            .iter()
+            .map(AsRef::as_ref)
+            .flat_map(find_trace_paths)
+            .collect()
+    };
+
+    ensure!(
+        !trace_paths.is_empty(),
+        "No traces found in the provided paths."
+    );
+
+    println!("Found traces:");
+    for path in &trace_paths {
+        println!("  {}", path.to_string_lossy());
+    }
+
+    Ok(trace_paths)
+}

--- a/src/argsv2/helpers.rs
+++ b/src/argsv2/helpers.rs
@@ -1,6 +1,8 @@
-use std::{ffi::{CStr, CString}, path::Path};
+use std::ffi::{CStr, CString};
+use std::path::Path;
 
-use bt2_sys::{graph::component::BtComponentType, query::support_info};
+use bt2_sys::graph::component::BtComponentType;
+use bt2_sys::query::support_info;
 use color_eyre::eyre::ensure;
 use walkdir::WalkDir;
 

--- a/src/argsv2/mod.rs
+++ b/src/argsv2/mod.rs
@@ -26,32 +26,35 @@ impl Args {
 
     pub fn get_analyses_args() -> &'static analysis_args::AnalysisArgs {
         match &Self::get().command {
-            TracerCommand::Analyse(analysis_args) => &analysis_args,
+            TracerCommand::Analyze(analysis_args) => analysis_args,
             _ => {
-                panic!("Tried to extract Analysis arguments subcommand while Charting subcommand has been provided")
+                panic!("Tried to extract Analysis arguments subcommand but {} subcommand was used", &Self::get().command)
             }
         }
     }
 
-    pub fn as_analysis_args(self) -> analysis_args::AnalysisArgs {
+    pub fn into_analysis_args(self) -> analysis_args::AnalysisArgs {
         match self.command {
-            TracerCommand::Analyse(analysis_args) => analysis_args,
+            TracerCommand::Analyze(analysis_args) => analysis_args,
             _ => {
-                panic!("Tried to extract Analysis arguments subcommand while Charting subcommand has been provided")
+                panic!("Tried to extract Analysis arguments subcommand but {} subcommand was used", self.command)
             }
         }
     }
 }
 
-#[derive(Debug, Subcommand, Clone)]
+#[derive(Debug, Subcommand, Clone, derive_more::Display)]
 pub enum TracerCommand {
-    /// Analyse a Ros2 trace and generate graphs, json or bundle outputs
-    Analyse(analysis_args::AnalysisArgs),
+    /// Analyze a ROS 2 trace and generate graphs, JSON or bundle outputs
+    #[display("analyze")]
+    Analyze(analysis_args::AnalysisArgs),
 
-    /// Render a chart of a specific property of a RoS2 interface
+    /// Render a chart of a specific property of a ROS 2 interface
+    #[display("chart")]
     Chart(chart_args::ChartArgs),
     
     /// Start a .dot viewer capable of generating charts on demand
+    #[display("viewer")]
     Viewer(viewer_args::ViewerArgs),
 }
 

--- a/src/argsv2/mod.rs
+++ b/src/argsv2/mod.rs
@@ -1,0 +1,84 @@
+use std::sync::OnceLock;
+
+use clap::{Parser, Subcommand};
+use clap_verbosity_flag::{Verbosity, WarnLevel};
+
+pub mod analysis_args;
+pub mod chart_args;
+pub mod viewer_args;
+pub mod helpers;
+
+pub static CLI_ARGS: OnceLock<Args> = OnceLock::new();
+
+#[derive(Debug, Clone, Parser)]
+pub struct Args {
+    #[command(flatten)]
+    pub verbose: Verbosity<WarnLevel>,
+
+    #[command(subcommand)]
+    pub command: TracerCommand,
+}
+
+impl Args {
+    pub fn get() -> &'static Args {
+        CLI_ARGS.get_or_init(Self::parse)
+    }
+
+    pub fn get_analyses_args() -> &'static analysis_args::AnalysisArgs {
+        match &Self::get().command {
+            TracerCommand::Analyse(analysis_args) => &analysis_args,
+            _ => {
+                panic!("Tried to extract Analysis arguments subcommand while Charting subcommand has been provided")
+            }
+        }
+    }
+
+    pub fn as_analysis_args(self) -> analysis_args::AnalysisArgs {
+        match self.command {
+            TracerCommand::Analyse(analysis_args) => analysis_args,
+            _ => {
+                panic!("Tried to extract Analysis arguments subcommand while Charting subcommand has been provided")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Subcommand, Clone)]
+pub enum TracerCommand {
+    /// Analyse a Ros2 trace and generate graphs, json or bundle outputs
+    Analyse(analysis_args::AnalysisArgs),
+
+    /// Render a chart of a specific property of a RoS2 interface
+    Chart(chart_args::ChartArgs),
+    
+    /// Start a .dot viewer capable of generating charts on demand
+    Viewer(viewer_args::ViewerArgs),
+}
+
+
+
+
+#[cfg(test)]
+mod test {
+    use clap::{CommandFactory};
+
+    use super::*;
+
+    #[test]
+    #[ignore]
+    fn print_help() {
+        Args::command().print_help().unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    fn print_long_help() {
+        Args::command().print_long_help().unwrap();
+    }
+
+    #[test]
+    fn verify_cli() {
+        Args::command().debug_assert();
+    }
+
+}

--- a/src/argsv2/mod.rs
+++ b/src/argsv2/mod.rs
@@ -5,8 +5,8 @@ use clap_verbosity_flag::{Verbosity, WarnLevel};
 
 pub mod analysis_args;
 pub mod chart_args;
-pub mod viewer_args;
 pub mod helpers;
+pub mod viewer_args;
 
 pub static CLI_ARGS: OnceLock<Args> = OnceLock::new();
 
@@ -28,7 +28,10 @@ impl Args {
         match &Self::get().command {
             TracerCommand::Analyze(analysis_args) => analysis_args,
             _ => {
-                panic!("Tried to extract Analysis arguments subcommand but {} subcommand was used", &Self::get().command)
+                panic!(
+                    "Tried to extract Analysis arguments subcommand but {} subcommand was used",
+                    &Self::get().command
+                )
             }
         }
     }
@@ -37,7 +40,10 @@ impl Args {
         match self.command {
             TracerCommand::Analyze(analysis_args) => analysis_args,
             _ => {
-                panic!("Tried to extract Analysis arguments subcommand but {} subcommand was used", self.command)
+                panic!(
+                    "Tried to extract Analysis arguments subcommand but {} subcommand was used",
+                    self.command
+                )
             }
         }
     }
@@ -52,18 +58,15 @@ pub enum TracerCommand {
     /// Render a chart of a specific property of a ROS 2 interface
     #[display("chart")]
     Chart(chart_args::ChartArgs),
-    
+
     /// Start a .dot viewer capable of generating charts on demand
     #[display("viewer")]
     Viewer(viewer_args::ViewerArgs),
 }
 
-
-
-
 #[cfg(test)]
 mod test {
-    use clap::{CommandFactory};
+    use clap::CommandFactory;
 
     use super::*;
 
@@ -83,5 +86,4 @@ mod test {
     fn verify_cli() {
         Args::command().debug_assert();
     }
-
 }

--- a/src/argsv2/viewer_args.rs
+++ b/src/argsv2/viewer_args.rs
@@ -10,7 +10,7 @@ pub struct ViewerArgs {
     /// The entry point to the python viewer (defaults to ./xdotviewer/main.py)
     pub viewer: Option<PathBuf>,
 
-    /// The executable to run to invoke the Ros2TraceAnalyzer (defaults to ./taget/release/Ros2TraceAnalyzer)
+    /// The executable to run to invoke the Ros2TraceAnalyzer (defaults to ./target/release/Ros2TraceAnalyzer)
     #[clap(long, short = 't', value_name = "Ros2TraceAnalyzer", value_hint = ValueHint::ExecutablePath)]
     pub tracer_exec: Option<PathBuf>,
 

--- a/src/argsv2/viewer_args.rs
+++ b/src/argsv2/viewer_args.rs
@@ -1,0 +1,20 @@
+use std::path::PathBuf;
+use clap::{Args, ValueHint};
+
+#[derive(Debug, Clone, Args)]
+pub struct ViewerArgs {
+    /// The dotfile to open
+    pub dotfile: PathBuf,
+
+    #[clap(long, value_name = "VIEWER", value_hint = ValueHint::FilePath)]
+    /// The entry point to the python viewer (defaults to ./xdotviewer/main.py)
+    pub viewer: Option<PathBuf>,
+
+    /// The executable to run to invoke the Ros2TraceAnalyzer (defaults to ./taget/release/Ros2TraceAnalyzer)
+    #[clap(long, short = 't', value_name = "Ros2TraceAnalyzer", value_hint = ValueHint::ExecutablePath)]
+    pub tracer_exec: Option<PathBuf>,
+
+    /// The directory with the datafiles (defaults to CWD)
+    #[clap(long, short = 'd', value_name = "DATA", value_hint = ValueHint::DirPath)]
+    pub data: Option<PathBuf>
+}

--- a/src/argsv2/viewer_args.rs
+++ b/src/argsv2/viewer_args.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use clap::{Args, ValueHint};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Args)]
 pub struct ViewerArgs {
@@ -16,5 +16,5 @@ pub struct ViewerArgs {
 
     /// The directory with the datafiles (defaults to CWD)
     #[clap(long, short = 'd', value_name = "DATA", value_hint = ValueHint::DirPath)]
-    pub data: Option<PathBuf>
+    pub data: Option<PathBuf>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,8 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use analysis::AnalysisOutputExt;
-use argsv2::{helpers::prepare_trace_paths, Args};
+use argsv2::helpers::prepare_trace_paths;
+use argsv2::Args;
 use color_eyre::eyre::{Context, Result};
 
 use crate::argsv2::analysis_args::AnalysisArgs;
@@ -252,7 +253,8 @@ impl Analyses {
 fn run_analysis<L: clap_verbosity_flag::LogLevel>(
     args: &AnalysisArgs,
     verbose: &clap_verbosity_flag::Verbosity<L>,
-) -> color_eyre::eyre::Result<()> {    let trace_paths = prepare_trace_paths()?;
+) -> color_eyre::eyre::Result<()> {
+    let trace_paths = prepare_trace_paths()?;
     let trace_paths_cstr: Vec<_> = trace_paths.iter().map(CString::as_c_str).collect();
     let mut iter = event_iterator::ProcessedEventsIter::new(&trace_paths_cstr, verbose);
 
@@ -384,15 +386,11 @@ fn run_analysis<L: clap_verbosity_flag::LogLevel>(
     Ok(())
 }
 
-fn run_charting(
-    args: &ChartArgs,
-) -> color_eyre::eyre::Result<()> {
+fn run_charting(args: &ChartArgs) -> color_eyre::eyre::Result<()> {
     Ok(())
 }
 
-fn run_viewer(
-    args: &ViewerArgs
-) -> color_eyre::eyre::Result<()> {
+fn run_viewer(args: &ViewerArgs) -> color_eyre::eyre::Result<()> {
     Ok(())
 }
 
@@ -406,7 +404,9 @@ fn main() -> color_eyre::eyre::Result<()> {
 
     let args = Args::get();
     match &args.command {
-        argsv2::TracerCommand::Analyze(analysis_args) => run_analysis(&analysis_args, &args.verbose),
+        argsv2::TracerCommand::Analyze(analysis_args) => {
+            run_analysis(&analysis_args, &args.verbose)
+        }
         argsv2::TracerCommand::Chart(chart_args) => run_charting(&chart_args),
         argsv2::TracerCommand::Viewer(viewer_args) => run_viewer(&viewer_args),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -406,7 +406,7 @@ fn main() -> color_eyre::eyre::Result<()> {
 
     let args = Args::get();
     match &args.command {
-        argsv2::TracerCommand::Analyse(analysis_args) => run_analysis(&analysis_args, &args.verbose),
+        argsv2::TracerCommand::Analyze(analysis_args) => run_analysis(&analysis_args, &args.verbose),
         argsv2::TracerCommand::Chart(chart_args) => run_charting(&chart_args),
         argsv2::TracerCommand::Viewer(viewer_args) => run_viewer(&viewer_args),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,12 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use analysis::AnalysisOutputExt;
-use argsv2::{prepare_trace_paths, Args};
+use argsv2::{helpers::prepare_trace_paths, Args};
 use color_eyre::eyre::{Context, Result};
+
+use crate::argsv2::analysis_args::AnalysisArgs;
+use crate::argsv2::chart_args::ChartArgs;
+use crate::argsv2::viewer_args::ViewerArgs;
 
 mod event_iterator {
     use std::ffi::CStr;
@@ -245,12 +249,12 @@ impl Analyses {
     }
 }
 
-fn run() -> color_eyre::eyre::Result<()> {
-    let args = Args::get();
-
-    let trace_paths = prepare_trace_paths()?;
+fn run_analysis<L: clap_verbosity_flag::LogLevel>(
+    args: &AnalysisArgs,
+    verbose: &clap_verbosity_flag::Verbosity<L>,
+) -> color_eyre::eyre::Result<()> {    let trace_paths = prepare_trace_paths()?;
     let trace_paths_cstr: Vec<_> = trace_paths.iter().map(CString::as_c_str).collect();
-    let mut iter = event_iterator::ProcessedEventsIter::new(&trace_paths_cstr, &args.verbose);
+    let mut iter = event_iterator::ProcessedEventsIter::new(&trace_paths_cstr, verbose);
 
     let mut analysis = Analyses::default();
 
@@ -380,6 +384,18 @@ fn run() -> color_eyre::eyre::Result<()> {
     Ok(())
 }
 
+fn run_charting(
+    args: &ChartArgs,
+) -> color_eyre::eyre::Result<()> {
+    Ok(())
+}
+
+fn run_viewer(
+    args: &ViewerArgs
+) -> color_eyre::eyre::Result<()> {
+    Ok(())
+}
+
 fn main() -> color_eyre::eyre::Result<()> {
     color_eyre::install()?;
 
@@ -388,5 +404,10 @@ fn main() -> color_eyre::eyre::Result<()> {
         .format_timestamp(None)
         .init();
 
-    run()
+    let args = Args::get();
+    match &args.command {
+        argsv2::TracerCommand::Analyse(analysis_args) => run_analysis(&analysis_args, &args.verbose),
+        argsv2::TracerCommand::Chart(chart_args) => run_charting(&chart_args),
+        argsv2::TracerCommand::Viewer(viewer_args) => run_viewer(&viewer_args),
+    }
 }


### PR DESCRIPTION
The current version of the CLI is hard to expand with future arguments/commands that do not directly relate to the analysis. This commit adresses that issue and proposes usage of Clap's `Subcommand` trait.

In this PR there are 4 new subcommands (`analyse`, `chart`, `viewer` and `extract`). One of these must go right after the exec. name (ex. `Ros2TraceAnalyzer analyse`) and the arguments of that subcommand (unchanged for `analyse`) can follow (ex. `Ros2TraceAnalyzer analyse --all ./my_trace`)
This simplifies adding new subcommands for new features instead of combining the arguments withe the current ones.