### PR TITLE
Support Kilted GID

### DIFF
--- a/bt2-derive/src/lib.rs
+++ b/bt2-derive/src/lib.rs
@@ -6,7 +6,7 @@ use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
 use syn::{parse_macro_input, Data, DeriveInput, Field, Fields, Ident};
 
-#[proc_macro_derive(TryFromBtFieldConst, attributes(bt2))]
+#[proc_macro_derive(TryFromBtFieldConst, attributes(bt2, allow_padding))]
 pub fn derive_try_from_bt_field_const(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
@@ -223,6 +223,19 @@ fn default_field_conversion(field: &Field) -> proc_macro2::TokenStream {
             .to_compile_error();
     };
     let field_span = field.span();
+
+    let allow_padding = field
+        .attrs
+        .iter()
+        .any(|a| a.path().is_ident("allow_padding"));
+
+    if allow_padding {
+        return quote_spanned! {field_span=>
+            bt2_sys::field::BtFieldArrayConstPaddable(
+                bt_field.try_into_array().map_err(|e| bt2_sys::field::StructConversionError::field_conversion_error(stringify!(#field_name), e))?
+            ).try_into().map_err(|e| bt2_sys::field::StructConversionError::field_conversion_error(stringify!(#field_name), e))?
+        };
+    }
 
     quote_spanned! {field_span=>
         bt_field.try_into().map_err(|e| bt2_sys::field::StructConversionError::field_conversion_error(stringify!(#field_name), e))?

--- a/bt2-sys/src/field.rs
+++ b/bt2-sys/src/field.rs
@@ -47,6 +47,10 @@ pub struct BtFieldArrayConst(BtFieldConst);
 
 #[repr(transparent)]
 #[derive(Deref)]
+pub struct BtFieldArrayConstPaddable(pub BtFieldArrayConst);
+
+#[repr(transparent)]
+#[derive(Deref)]
 pub struct BtFieldStructureConst(BtFieldConst);
 
 /// Casted [`BtFieldConst`] to more specific field types.
@@ -819,6 +823,62 @@ where
     }
 }
 
+impl<const N: usize, T> TryFrom<BtFieldArrayConstPaddable> for [T; N]
+where
+    T: TryFrom<BtFieldConst> + Copy + std::fmt::Debug,
+    <T as TryFrom<BtFieldConst>>::Error: Into<ConversionError>,
+{
+    type Error = ArrayConversionError;
+
+    fn try_from(bt_array: BtFieldArrayConstPaddable) -> Result<Self, Self::Error> {
+        let len = bt_array.get_length();
+        if len > N as u64 {
+            return Err(ArrayConversionError::CannotPadArray {
+                max: N as u64,
+                actual: len,
+            });
+        }
+
+        let mut array = [const { MaybeUninit::uninit() }; N];
+        let mut i = 0;
+
+        let (init, err) = loop {
+            if i >= len {
+                break (len, None);
+            }
+
+            let elem = bt_array.get_value(i).try_into().map_err(
+                |e: <T as TryFrom<BtFieldConst>>::Error| {
+                    ArrayConversionError::element_conversion_error(e, i)
+                },
+            );
+
+            match elem {
+                Ok(elem) => array[i as usize] = MaybeUninit::new(elem),
+                Err(e) => break (i, Some(e)),
+            }
+
+            i += 1;
+        };
+
+        if let Some(err) = err {
+            for elem in array.iter_mut().take(init as usize) {
+                unsafe {
+                    elem.assume_init_drop();
+                }
+            }
+
+            return Err(err);
+        }
+
+        for i in (len as usize)..N {
+            array[i] = array[(len - 1) as usize];
+        }
+
+        Ok(array.map(|elem| unsafe { elem.assume_init() }))
+    }
+}
+
 impl<T> TryFrom<BtFieldArrayConst> for Vec<T>
 where
     T: TryFrom<BtFieldConst>,
@@ -1230,6 +1290,9 @@ pub enum ArrayConversionError {
 
     #[error("Array length could not fit in usize: {0}")]
     LengthTooLarge(u64),
+
+    #[error("Array must be shorter to allow padding: expected <= {max}, got: {actual}")]
+    CannotPadArray { max: u64, actual: u64 },
 }
 
 impl ArrayConversionError {

--- a/src/raw_events/ros2.rs
+++ b/src/raw_events/ros2.rs
@@ -29,6 +29,7 @@ pub struct RclNodeInit {
 pub struct RmwPublisherInit {
     #[debug("{rmw_publisher_handle:#x}")]
     pub rmw_publisher_handle: u64,
+    #[allow_padding]
     pub gid: [u8; GID_SIZE],
 }
 
@@ -79,6 +80,7 @@ pub struct RmwPublish {
 pub struct RmwSubscriptionInit {
     #[debug("{rmw_subscription_handle:#x}")]
     pub rmw_subscription_handle: u64,
+    #[allow_padding]
     pub gid: [u8; GID_SIZE],
 }
 


### PR DESCRIPTION
RMW GIDs on ROS 2 Kilted were shortened from 24B to 16B. This breaks the parsing of the field from BT. To support all versions the internal GID are kept as 24B and are appended with the last byte until full. 

[ros2_tracing#138](https://github.com/ros2/ros2_tracing/pull/138)
[ros2_rmw#345](https://github.com/ros2/rmw/pull/345)