### PR TITLE
Fixes for failing tests proposed in PR #12

### DIFF
--- a/src/analyses/analysis/callback_dependency.rs
+++ b/src/analyses/analysis/callback_dependency.rs
@@ -3,8 +3,9 @@ use std::sync::{Arc, Mutex};
 
 use graph::Graph;
 
-use crate::model::{Callback, CallbackType};
+use crate::model::{Callback, CallbackCaller, CallbackType};
 use crate::processed_events::{Event, FullEvent, ros2};
+use crate::utils::Known;
 
 use super::{ArcMutWrapper, EventAnalysis, PublicationInCallback};
 
@@ -110,6 +111,7 @@ pub mod graph {
 pub struct CallbackDependency {
     timer_driven_callbacks: Vec<ArcMutWrapper<Callback>>,
     message_driven_callbacks: Vec<ArcMutWrapper<Callback>>,
+    service_driven_callbacks: Vec<ArcMutWrapper<Callback>>,
     publication_in_callback: PublicationInCallback,
     graph: Option<Box<Graph>>,
 }
@@ -131,8 +133,7 @@ impl CallbackDependency {
                 self.message_driven_callbacks.push(callback_arc.into());
             }
             CallbackType::Service => {
-                // Ignore service callbacks for now
-                // TODO: Handle service callbacks
+                self.service_driven_callbacks.push(callback_arc.into());
             }
         }
     }
@@ -142,11 +143,20 @@ impl CallbackDependency {
         let mut edges = Vec::new();
 
         let mut callback_to_node = HashMap::new();
-        let mut topic_to_nodes = HashMap::<_, Vec<_>>::new();
+        let mut topic_to_nodes = HashMap::<Known<String>, Vec<_>>::new();
 
         let mut sources = Vec::new();
 
         for callback in &self.timer_driven_callbacks {
+            let node = graph::Node::new(callback.0.clone());
+
+            let id = nodes.len();
+            nodes.push(node);
+            sources.push(id);
+            callback_to_node.insert(callback.clone(), id);
+        }
+
+        for callback in &self.service_driven_callbacks {
             let node = graph::Node::new(callback.0.clone());
 
             let id = nodes.len();
@@ -163,22 +173,32 @@ impl CallbackDependency {
             callback_to_node.insert(callback.clone(), id);
 
             let callback = callback.0.lock().unwrap();
-            let subscriber = callback.get_caller().unwrap().unwrap_subscription_ref();
-
-            let subscriber = subscriber.get_arc().expect("Subscriber should be alive");
-            let subscriber = subscriber.lock().unwrap();
-            let topic = subscriber.get_topic().unwrap().to_owned();
+            let topic = callback
+                .get_caller()
+                .and_then(|caller| match caller {
+                    CallbackCaller::Subscription(subscriber) => subscriber.get_arc(),
+                    _ => None,
+                })
+                .map_or(Known::Unknown, |subscriber| {
+                    subscriber.lock().unwrap().get_topic().map(str::to_owned)
+                });
 
             topic_to_nodes.entry(topic).or_default().push(id);
         }
 
         for (publisher, callback) in self.publication_in_callback.get_dependency() {
+            let source_node = *callback_to_node.entry(callback.clone()).or_insert_with(|| {
+                let id = nodes.len();
+                let node = graph::Node::new(callback.0.clone());
+                nodes.push(node);
+                id
+            });
             let publisher = publisher.0.lock().unwrap();
-            let topic = publisher.get_topic().unwrap().to_owned();
+            let topic = publisher.get_topic().map(str::to_owned);
 
             if let Some(nodes) = topic_to_nodes.get(&topic) {
                 for &node in nodes {
-                    edges.push((callback_to_node[callback], node));
+                    edges.push((source_node, node));
                 }
             }
         }

--- a/src/analyses/analysis/dependency_graph.rs
+++ b/src/analyses/analysis/dependency_graph.rs
@@ -538,6 +538,7 @@ impl EventAnalysis for DependencyGraph {
 
 struct EdgeWeightStats {
     subscriber_to_callback: (i64, i64),
+    service_to_callback: (i64, i64),
     timer_to_callback: (i64, i64),
     callback_to_publisher: (i64, i64),
 }
@@ -551,6 +552,11 @@ impl EdgeWeightStats {
     fn update_timer_to_callback(&mut self, latency: i64) {
         self.timer_to_callback.0 = self.timer_to_callback.0.min(latency);
         self.timer_to_callback.1 = self.timer_to_callback.1.max(latency);
+    }
+
+    fn update_service_to_callback(&mut self, latency: i64) {
+        self.service_to_callback.0 = self.service_to_callback.0.min(latency);
+        self.service_to_callback.1 = self.service_to_callback.1.max(latency);
     }
 
     fn update_callback_to_publisher(&mut self, latency: i64) {
@@ -571,11 +577,10 @@ impl EdgeWeightStats {
             EdgeType::SubscriberCallbackInvocation => {
                 Self::validate_range(self.subscriber_to_callback)
             }
+            EdgeType::ServiceCallbackInvocation => Self::validate_range(self.service_to_callback),
             EdgeType::TimerCallbackInvocation => Self::validate_range(self.timer_to_callback),
             EdgeType::PublicationInCallback => Self::validate_range(self.callback_to_publisher),
-            EdgeType::ServiceCallbackInvocation | EdgeType::PublisherSubscriberCommunication => {
-                None
-            }
+            EdgeType::PublisherSubscriberCommunication => None,
         }
     }
 }
@@ -584,6 +589,7 @@ impl Default for EdgeWeightStats {
     fn default() -> Self {
         Self {
             subscriber_to_callback: (i64::MAX, i64::MIN),
+            service_to_callback: (i64::MAX, i64::MIN),
             timer_to_callback: (i64::MAX, i64::MIN),
             callback_to_publisher: (i64::MAX, i64::MIN),
         }
@@ -672,6 +678,27 @@ impl<'a> DisplayAsDot<'a> {
             graph_node_to_ros_node.insert(node, ros_node.clone().into());
         }
 
+        let service_nodes = graph
+            .edges
+            .keys()
+            .filter_map(|edge| match edge {
+                Edge::ServiceCallbackInvocation(service, _) => Some(service.clone()),
+                _ => None,
+            })
+            .collect::<HashSet<_>>();
+        for service in service_nodes {
+            let node = Node::Service(service.clone());
+            node_to_id.insert(node.clone(), graph_node_id);
+            graph_node_id += 1;
+
+            let service = service.0.lock().unwrap();
+            if let Known::Known(ros_node_arc) = service.get_node() {
+                if let Some(ros_node) = ros_node_arc.get_arc() {
+                    graph_node_to_ros_node.insert(node, ros_node.into());
+                }
+            }
+        }
+
         let unique_used_ros_nodes = graph_node_to_ros_node
             .values()
             .collect::<HashSet<_>>()
@@ -725,13 +752,35 @@ fn process_edges(
 
     for (edge, edge_data) in graph_edges {
         let latencies = Sorted::from_unsorted(&edge_data.latencies);
-        let median = *latencies.median().unwrap();
+        let Some(median) = latencies.median().copied() else {
+            log::warn!("Skipping edge without latency samples: {edge:?}");
+            continue;
+        };
         let edge_type = edge.as_type();
 
         let source = edge.source();
         let target = edge.target();
-        let source_ros_node = &graph_node_to_ros_node[&source];
-        let target_ros_node = &graph_node_to_ros_node[&target];
+        let Some(source_id) = node_to_id.get(&source).copied() else {
+            log::warn!("Skipping edge {edge_type:?}: source node missing from id map: {source:?}");
+            continue;
+        };
+        let Some(target_id) = node_to_id.get(&target).copied() else {
+            log::warn!("Skipping edge {edge_type:?}: target node missing from id map: {target:?}");
+            continue;
+        };
+
+        let Some(source_ros_node) = graph_node_to_ros_node.get(&source) else {
+            log::warn!(
+                "Skipping edge {edge_type:?}: source ROS-node mapping missing for {source:?}"
+            );
+            continue;
+        };
+        let Some(target_ros_node) = graph_node_to_ros_node.get(&target) else {
+            log::warn!(
+                "Skipping edge {edge_type:?}: target ROS-node mapping missing for {target:?}"
+            );
+            continue;
+        };
 
         let node_id = match edge_type {
             EdgeType::PublisherSubscriberCommunication => {
@@ -744,30 +793,31 @@ fn process_edges(
                     .entry(source_ros_node.clone())
                     .or_default()
                     .update_subscriber_to_callback(median);
-                Some(ros_node_to_id[source_ros_node])
+                ros_node_to_id.get(source_ros_node).copied()
+            }
+            EdgeType::ServiceCallbackInvocation if source_ros_node == target_ros_node => {
+                ros_nodes_min_max_latency_stats
+                    .entry(source_ros_node.clone())
+                    .or_default()
+                    .update_service_to_callback(median);
+                ros_node_to_id.get(source_ros_node).copied()
             }
             EdgeType::TimerCallbackInvocation if source_ros_node == target_ros_node => {
                 ros_nodes_min_max_latency_stats
                     .entry(source_ros_node.clone())
                     .or_default()
                     .update_timer_to_callback(median);
-                Some(ros_node_to_id[source_ros_node])
+                ros_node_to_id.get(source_ros_node).copied()
             }
             EdgeType::PublicationInCallback if source_ros_node == target_ros_node => {
                 ros_nodes_min_max_latency_stats
                     .entry(source_ros_node.clone())
                     .or_default()
                     .update_callback_to_publisher(median);
-                Some(ros_node_to_id[source_ros_node])
+                ros_node_to_id.get(source_ros_node).copied()
             }
-            _ => {
-                // ServiceToCallback: Service is represented by its callback so the latency is always 0.
-                None
-            }
+            _ => None,
         };
-
-        let source_id = node_to_id[&source];
-        let target_id = node_to_id[&target];
 
         edges.push(DisplayAsDotEdge {
             source: source_id,
@@ -869,9 +919,19 @@ impl std::fmt::Display for DisplayAsDot<'_> {
 
         let mut clusters = vec![Vec::new(); self.ros_node_to_id.len()];
         for (node, ros_node) in &self.graph_node_to_ros_node {
-            let id = self.ros_node_to_id[ros_node];
-            let graph_node_id = self.node_to_id[node];
-            clusters[id].push(graph_node_id);
+            let Some(id) = self.ros_node_to_id.get(ros_node).copied() else {
+                log::warn!(
+                    "Skipping cluster placement due to missing ROS-node id for node {node:?}"
+                );
+                continue;
+            };
+            let Some(graph_node_id) = self.node_to_id.get(node).copied() else {
+                log::warn!("Skipping cluster placement due to missing graph node id for {node:?}");
+                continue;
+            };
+            if let Some(cluster) = clusters.get_mut(id) {
+                cluster.push(graph_node_id);
+            }
         }
 
         let mut graph = graphviz_export::Graph::new();
@@ -910,8 +970,10 @@ impl std::fmt::Display for DisplayAsDot<'_> {
                 EdgeType::PublisherSubscriberCommunication => self.pub_sub_latency_range,
                 _ => {
                     if let Some(node_id) = edge.node_index {
-                        self.ros_nodes_min_max_latency_stats[&self.ros_nodes[node_id]]
-                            .range_for_type(edge.edge_type)
+                        self.ros_nodes
+                            .get(node_id)
+                            .and_then(|node| self.ros_nodes_min_max_latency_stats.get(node))
+                            .and_then(|stats| stats.range_for_type(edge.edge_type))
                     } else {
                         None
                     }


### PR DESCRIPTION
Some of the crashes are related to insufficient service support in Ros2TraceAnalyzer.

Services weren't supported because of some callback issues in jazzy probably related to https://github.com/ros2/rclcpp/pull/2670

- fix crashes related to unknown sources in callback dep. and DOT graph
- include service nodes/edges in dependency DOT output
- include services in callback dependency analysis