### PR TITLE
Fix clippy lints

### DIFF
--- a/src/analyses/analysis/callback_duration.rs
+++ b/src/analyses/analysis/callback_duration.rs
@@ -210,7 +210,7 @@ impl CallbackDuration {
         }
     }
 
-    pub fn get_durations_for_callback(
+    pub(super) fn get_durations_for_callback(
         &self,
         callback: &ArcMutWrapper<Callback>,
     ) -> Option<Vec<i64>> {
@@ -219,7 +219,7 @@ impl CallbackDuration {
             .map(|data| data.iter().map(|data| data.duration).collect::<Vec<_>>())
     }
 
-    pub fn get_all_durations(&self) -> HashMap<ArcMutWrapper<Callback>, Vec<i64>> {
+    pub(super) fn get_all_durations(&self) -> HashMap<ArcMutWrapper<Callback>, Vec<i64>> {
         self.execution_data
             .iter()
             .map(|(k, v)| (k.clone(), v.iter().map(|data| data.duration).collect()))
@@ -243,12 +243,17 @@ impl CallbackDuration {
         Some(inter_callback_time)
     }
 
-    pub fn get_inter_arrival_time(&self, callback: &ArcMutWrapper<Callback>) -> Option<Vec<i64>> {
+    pub(super) fn get_inter_arrival_time(
+        &self,
+        callback: &ArcMutWrapper<Callback>,
+    ) -> Option<Vec<i64>> {
         let start_times = self.execution_data.get(callback)?;
         Self::get_inter_arrival_time_inner(start_times)
     }
 
-    pub fn get_execution_data(&self) -> &HashMap<ArcMutWrapper<Callback>, Vec<ExecutionData>> {
+    pub(super) fn get_execution_data(
+        &self,
+    ) -> &HashMap<ArcMutWrapper<Callback>, Vec<ExecutionData>> {
         &self.execution_data
     }
 }

--- a/src/analyses/analysis/callback_duration.rs
+++ b/src/analyses/analysis/callback_duration.rs
@@ -3,13 +3,11 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::vec::Vec;
 
-use crate::argsv2::Args;
 use crate::events_common::Context;
-use crate::model::display::{DisplayCallbackSummary, get_node_name_from_weak};
+use crate::model::display::get_node_name_from_weak;
 use crate::model::{Callback, CallbackInstance, Time};
 use crate::processed_events::{Event, FullEvent, ros2};
-use crate::statistics::{Quantile, Sorted};
-use crate::utils::{DurationDisplayImprecise, WeakKnown};
+use crate::utils::WeakKnown;
 
 use super::{AnalysisOutput, ArcMutWrapper, EventAnalysis};
 
@@ -51,12 +49,6 @@ pub struct Record {
 
     durations: Vec<i64>,
     inter_arrival_times: Vec<i64>,
-}
-
-#[derive(Debug, Clone)]
-pub struct RecordSummary {
-    pub(crate) call_count: usize,
-    pub(crate) quantiles: Vec<(Quantile, i64)>,
 }
 
 impl CallbackDuration {
@@ -134,36 +126,6 @@ impl CallbackDuration {
             .collect();
     }
 
-    fn calculate_duration_summary(
-        &self,
-        callback: &ArcMutWrapper<Callback>,
-    ) -> Option<RecordSummary> {
-        let exec_data = self.execution_data.get(callback)?;
-        debug_assert!(
-            !exec_data.is_empty(),
-            "Callback should have at least one execution data. Otherwise, it should not be present in the map."
-        );
-
-        let dur_len = exec_data.len();
-        let mut durations: Vec<i64> = exec_data.iter().map(|data| data.duration).collect();
-        durations.sort_unstable();
-        let durations_sorted = Sorted::from_sorted(durations).unwrap();
-
-        let duration_quantiles = Args::get_analyses_args()
-            .quantiles()
-            .iter()
-            .map(|q| {
-                let duration = *durations_sorted.quantile(*q).expect("Should not be empty");
-                (*q, duration)
-            })
-            .collect::<Vec<_>>();
-
-        Some(RecordSummary {
-            call_count: dur_len,
-            quantiles: duration_quantiles,
-        })
-    }
-
     pub fn get_records(&self) -> Vec<Record> {
         self.execution_data
             .iter()
@@ -185,44 +147,6 @@ impl CallbackDuration {
                         .unwrap_or_default(),
                 }
             })
-            .collect()
-    }
-
-    pub(crate) fn print_stats(&self) {
-        println!("Callback duration statistics:");
-        for (i, callback_arc) in self.execution_data.keys().enumerate() {
-            let callback = callback_arc.0.lock().unwrap();
-            let summary = self
-                .calculate_duration_summary(callback_arc)
-                .expect("Callback key should exist.");
-
-            println!("- [{i:4}] Callback {}:", DisplayCallbackSummary(&callback));
-            println!("    Call count: {}", summary.call_count);
-            if summary.call_count > 0 {
-                println!("    Duration quantiles:");
-                for (quantile, duration) in &summary.quantiles {
-                    println!(
-                        "        {quantile:5}: {duration_display}",
-                        duration_display = DurationDisplayImprecise(*duration),
-                    );
-                }
-            }
-        }
-    }
-
-    pub(super) fn get_durations_for_callback(
-        &self,
-        callback: &ArcMutWrapper<Callback>,
-    ) -> Option<Vec<i64>> {
-        self.execution_data
-            .get(callback)
-            .map(|data| data.iter().map(|data| data.duration).collect::<Vec<_>>())
-    }
-
-    pub(super) fn get_all_durations(&self) -> HashMap<ArcMutWrapper<Callback>, Vec<i64>> {
-        self.execution_data
-            .iter()
-            .map(|(k, v)| (k.clone(), v.iter().map(|data| data.duration).collect()))
             .collect()
     }
 

--- a/src/analyses/analysis/dependency_graph.rs
+++ b/src/analyses/analysis/dependency_graph.rs
@@ -174,7 +174,7 @@ impl DependencyGraph {
         color: bool,
         thickness: bool,
         min_multiplier: f64,
-    ) -> DisplayAsDot {
+    ) -> DisplayAsDot<'_> {
         DisplayAsDot::new(self, color, thickness, min_multiplier)
     }
 }

--- a/src/analyses/analysis/dependency_graph.rs
+++ b/src/analyses/analysis/dependency_graph.rs
@@ -117,13 +117,13 @@ enum EdgeType {
 impl Edge {
     fn source(&self) -> Node {
         match self {
-            Edge::PublicationInCallback(_publisher, callback) => Node::Callback(callback.clone()),
-            Edge::SubscriberCallbackInvocation(subscriber, _callback) => {
+            Self::PublicationInCallback(_publisher, callback) => Node::Callback(callback.clone()),
+            Self::SubscriberCallbackInvocation(subscriber, _callback) => {
                 Node::Subscriber(subscriber.clone())
             }
-            Edge::ServiceCallbackInvocation(service, _callback) => Node::Service(service.clone()),
-            Edge::TimerCallbackInvocation(timer, _callback) => Node::Timer(timer.clone()),
-            Edge::PublisherSubscriberCommunication(publisher, _subscriber) => {
+            Self::ServiceCallbackInvocation(service, _callback) => Node::Service(service.clone()),
+            Self::TimerCallbackInvocation(timer, _callback) => Node::Timer(timer.clone()),
+            Self::PublisherSubscriberCommunication(publisher, _subscriber) => {
                 Node::Publisher(publisher.clone())
             }
         }
@@ -131,13 +131,13 @@ impl Edge {
 
     fn target(&self) -> Node {
         match self {
-            Edge::PublicationInCallback(publisher, _callback) => Node::Publisher(publisher.clone()),
-            Edge::SubscriberCallbackInvocation(_subscriber, callback) => {
+            Self::PublicationInCallback(publisher, _callback) => Node::Publisher(publisher.clone()),
+            Self::SubscriberCallbackInvocation(_subscriber, callback) => {
                 Node::Callback(callback.clone())
             }
-            Edge::ServiceCallbackInvocation(_service, callback) => Node::Callback(callback.clone()),
-            Edge::TimerCallbackInvocation(_timer, callback) => Node::Callback(callback.clone()),
-            Edge::PublisherSubscriberCommunication(_publisher, subscriber) => {
+            Self::ServiceCallbackInvocation(_service, callback) => Node::Callback(callback.clone()),
+            Self::TimerCallbackInvocation(_timer, callback) => Node::Callback(callback.clone()),
+            Self::PublisherSubscriberCommunication(_publisher, subscriber) => {
                 Node::Subscriber(subscriber.clone())
             }
         }
@@ -145,11 +145,11 @@ impl Edge {
 
     pub fn as_type(&self) -> EdgeType {
         match self {
-            Edge::PublicationInCallback(_, _) => EdgeType::PublicationInCallback,
-            Edge::SubscriberCallbackInvocation(_, _) => EdgeType::SubscriberCallbackInvocation,
-            Edge::ServiceCallbackInvocation(_, _) => EdgeType::ServiceCallbackInvocation,
-            Edge::TimerCallbackInvocation(_, _) => EdgeType::TimerCallbackInvocation,
-            Edge::PublisherSubscriberCommunication(_, _) => {
+            Self::PublicationInCallback(_, _) => EdgeType::PublicationInCallback,
+            Self::SubscriberCallbackInvocation(_, _) => EdgeType::SubscriberCallbackInvocation,
+            Self::ServiceCallbackInvocation(_, _) => EdgeType::ServiceCallbackInvocation,
+            Self::TimerCallbackInvocation(_, _) => EdgeType::TimerCallbackInvocation,
+            Self::PublisherSubscriberCommunication(_, _) => {
                 EdgeType::PublisherSubscriberCommunication
             }
         }

--- a/src/analyses/analysis/dependency_graph.rs
+++ b/src/analyses/analysis/dependency_graph.rs
@@ -49,7 +49,7 @@ pub struct DependencyGraph {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Node {
+enum Node {
     Publisher(ArcMutWrapper<Publisher>),
     Subscriber(ArcMutWrapper<Subscriber>),
     Service(ArcMutWrapper<Service>),

--- a/src/analyses/analysis/message_latency.rs
+++ b/src/analyses/analysis/message_latency.rs
@@ -12,6 +12,8 @@ use crate::utils::Known;
 use super::{AnalysisOutput, ArcMutWrapper, EventAnalysis};
 
 type SubPubKey = (ArcMutWrapper<Subscriber>, Option<ArcMutWrapper<Publisher>>);
+
+#[derive(Debug, Default)]
 pub struct MessageLatency {
     messages: HashSet<ArcMutWrapper<SubscriptionMessage>>,
     latencies: HashMap<SubPubKey, Vec<i64>>,
@@ -80,10 +82,7 @@ impl PartialOrd for MessageLatencyStats {
 
 impl MessageLatency {
     pub fn new() -> Self {
-        Self {
-            messages: HashSet::new(),
-            latencies: HashMap::new(),
-        }
+        Self::default()
     }
 
     fn add_message(&mut self, message: Arc<Mutex<SubscriptionMessage>>) {

--- a/src/analyses/analysis/message_latency.rs
+++ b/src/analyses/analysis/message_latency.rs
@@ -4,11 +4,10 @@ use std::sync::{Arc, Mutex};
 
 use serde::Serialize;
 
-use crate::analysis::utils::DisplayDurationStats;
 use crate::model::display::get_node_name_from_weak;
 use crate::model::{Publisher, Subscriber, SubscriptionMessage};
 use crate::processed_events::{Event, FullEvent, ros2};
-use crate::utils::{DurationDisplayImprecise, Known};
+use crate::utils::Known;
 
 use super::{AnalysisOutput, ArcMutWrapper, EventAnalysis};
 
@@ -174,33 +173,6 @@ impl MessageLatency {
                 }
             })
             .collect()
-    }
-
-    pub(crate) fn print_stats(&self) {
-        println!("Message latency statistics:");
-        let mut stats = self.calculate_stats();
-        stats.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
-        for (i, stat) in stats.iter().enumerate() {
-            let subscriber = stat.subscriber.lock().unwrap();
-            let topic = &stat.topic;
-            let publisher = stat.publisher.as_ref().map(|p| p.lock().unwrap());
-
-            println!("- [{i:4}] Topic {topic}:");
-            println!("    Subscriber: {subscriber:#}");
-            if let Some(publisher) = publisher {
-                println!("    Publisher: {publisher}");
-            } else {
-                println!("    Publisher: Unknown");
-            }
-            let display = DisplayDurationStats::new(&stat.latencies, "\n\t");
-            println!("\t{display}");
-            let (mean, std_dev) = display.mean_and_std_dev();
-            println!(
-                "\tMean: {}, Std. dev.: {}",
-                DurationDisplayImprecise(mean),
-                DurationDisplayImprecise(std_dev as i64)
-            );
-        }
     }
 }
 

--- a/src/analyses/analysis/message_take_to_callback_execution_latency.rs
+++ b/src/analyses/analysis/message_take_to_callback_execution_latency.rs
@@ -1,11 +1,8 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use crate::analysis::utils::DisplayDurationStats;
-use crate::model::display::DisplayCallbackSummary;
 use crate::model::{Callback, CallbackInstance, CallbackTrigger};
 use crate::processed_events::{Event, FullEvent, ros2};
-use crate::utils::DurationDisplayImprecise;
 
 use super::{AnalysisOutput, ArcMutWrapper, EventAnalysis};
 
@@ -34,24 +31,6 @@ impl MessageTakeToCallbackLatency {
                 .push(latency);
         } else {
             // Ignore other triggers
-        }
-    }
-
-    pub(crate) fn print_stats(&self) {
-        println!("Message take to callback execution latency statistics:");
-        for (i, (callback, latencies)) in self.latencies.iter().enumerate() {
-            let callback = callback.0.lock().unwrap();
-
-            println!("- [{i:4}] Callback {}:", DisplayCallbackSummary(&callback));
-            println!("    Call count: {}", latencies.len());
-            let display = DisplayDurationStats::with_comma(latencies);
-            println!("    Latency: {display}");
-            let (mean, std_dev) = display.mean_and_std_dev();
-            println!(
-                "    Mean: {}, Std. dev.: {}",
-                DurationDisplayImprecise(mean),
-                DurationDisplayImprecise(std_dev as i64)
-            );
         }
     }
 }

--- a/src/analyses/analysis/mod.rs
+++ b/src/analyses/analysis/mod.rs
@@ -64,7 +64,7 @@ pub trait AnalysisOutputExt: AnalysisOutput {
 impl<T: AnalysisOutput> AnalysisOutputExt for T {}
 
 #[derive(Debug, From)]
-struct ArcMutWrapper<T>(Arc<Mutex<T>>);
+pub(super) struct ArcMutWrapper<T>(Arc<Mutex<T>>);
 
 impl<T> PartialEq for ArcMutWrapper<T> {
     fn eq(&self, other: &Self) -> bool {

--- a/src/analyses/analysis/spin_duration.rs
+++ b/src/analyses/analysis/spin_duration.rs
@@ -17,7 +17,7 @@ impl SpinDuration {
         Self::default()
     }
 
-    pub(crate) fn print_stats(&self) {
+    pub fn print_stats(&self) {
         println!("Spin duration statistics:");
         for (i, (node, durations)) in self.processing_durations.iter().enumerate() {
             let node = node.0.lock().unwrap();

--- a/src/analyses/analysis/utilization.rs
+++ b/src/analyses/analysis/utilization.rs
@@ -109,7 +109,7 @@ impl<'a> Utilization<'a> {
         thread_utilization
     }
 
-    pub fn calculate_utilization_per_callback_real(
+    pub(super) fn calculate_utilization_per_callback_real(
         &self,
     ) -> HashMap<ArcMutWrapper<Callback>, HashMap<u32, f64>> {
         self.calculate_utilization_per_callback_internal(
@@ -126,7 +126,7 @@ impl<'a> Utilization<'a> {
         )
     }
 
-    pub fn calculate_utilization_per_callback(
+    pub(super) fn calculate_utilization_per_callback(
         &self,
         execution_duration_quantile: Quantile,
     ) -> HashMap<ArcMutWrapper<Callback>, HashMap<u32, f64>> {
@@ -164,7 +164,7 @@ impl<'a> Utilization<'a> {
         )
     }
 
-    pub fn calculate_total_utilization(
+    pub(super) fn calculate_total_utilization(
         thread_utilization_per_callback: &HashMap<ArcMutWrapper<Callback>, HashMap<u32, f64>>,
     ) -> HashMap<(String, u32), f64> {
         let mut utilization_per_thread_map = HashMap::new();

--- a/src/analyses/analysis/utils.rs
+++ b/src/analyses/analysis/utils.rs
@@ -6,19 +6,15 @@ pub struct DisplayDurationStats<'a>(&'a [i64], &'a str);
 
 impl<'a> DisplayDurationStats<'a> {
     pub fn with_newline(slice: &'a [i64]) -> Self {
-        Self(slice, "\n")
+        Self::new(slice, "\n")
     }
 
     pub fn with_comma(slice: &'a [i64]) -> Self {
-        Self(slice, ", ")
+        Self::new(slice, ", ")
     }
 
     pub fn new(slice: &'a [i64], separator: &'a str) -> Self {
         Self(slice, separator)
-    }
-
-    pub(crate) fn print(&self) {
-        println!("{self}");
     }
 
     pub fn mean_and_std_dev(&self) -> (i64, f64) {
@@ -30,7 +26,7 @@ impl<'a> DisplayDurationStats<'a> {
         let variance = self
             .0
             .iter()
-            .map(|&x| (x - mean))
+            .map(|&x| x - mean)
             .map(|x| i128::from(x) * i128::from(x))
             .sum::<i128>()
             / (self.0.len() - 1) as i128;

--- a/src/analyses/event_iterator.rs
+++ b/src/analyses/event_iterator.rs
@@ -62,11 +62,6 @@ impl<'a> ProcessedEventsIter<'a> {
         }
     }
 
-    pub(crate) fn add_analysis(&mut self, analysis: &'a mut dyn analysis::EventAnalysis) {
-        analysis.initialize();
-        self.analyses.push(analysis);
-    }
-
     pub(crate) fn add_add_analysis(
         &mut self,
         analyses: impl IntoIterator<Item = &'a mut dyn analysis::EventAnalysis>,
@@ -95,22 +90,6 @@ impl<'a> ProcessedEventsIter<'a> {
         - unsupported: {}\n\
         Other events: {}\n\
         Other messages: {}",
-            self.ros_processed_events,
-            self.ros_processing_failures,
-            self.ros_unsupported_events,
-            self.other_events,
-            self.other_messages
-        );
-    }
-
-    pub(crate) fn print_counters(&self) {
-        println!(
-            "Ros events:\n\
-            - processed: {}\n\
-            - failed to process: {}\n\
-            - unsupported: {}\n\
-            Other events: {}\n\
-            Other messages: {}",
             self.ros_processed_events,
             self.ros_processing_failures,
             self.ros_unsupported_events,
@@ -169,7 +148,6 @@ impl Iterator for ProcessedEventsIter<'_> {
                 Ok(processor::MaybeProcessed::Raw(raw)) => {
                     self.ros_unsupported_events += 1;
                     (self.on_unprocessed_event)(raw);
-                    continue;
                 }
                 Err(err) => {
                     self.ros_processing_failures += 1;

--- a/src/argsv2/analysis_args.rs
+++ b/src/argsv2/analysis_args.rs
@@ -196,55 +196,55 @@ impl AnalysisArgs {
         self.spin_duration.is_some()
     }
 
-    pub fn dependency_graph_path(&self) -> Option<Cow<Path>> {
+    pub fn dependency_graph_path(&self) -> Option<Cow<'_, Path>> {
         self.dependency_graph
             .as_ref()
             .map(|p| self.concatenate_with_out_path(p))
     }
 
-    pub fn message_latency_path(&self) -> Option<Cow<Path>> {
+    pub fn message_latency_path(&self) -> Option<Cow<'_, Path>> {
         self.message_latency
             .as_ref()
             .map(|p| self.concatenate_with_out_path(p))
     }
 
-    pub fn callback_duration_path(&self) -> Option<Cow<Path>> {
+    pub fn callback_duration_path(&self) -> Option<Cow<'_, Path>> {
         self.callback_duration
             .as_ref()
             .map(|p| self.concatenate_with_out_path(p))
     }
 
-    pub fn callback_publications_path(&self) -> Option<Cow<Path>> {
+    pub fn callback_publications_path(&self) -> Option<Cow<'_, Path>> {
         self.callback_publications
             .as_ref()
             .map(|p| self.concatenate_with_out_path(p))
     }
 
-    pub fn callback_dependency_path(&self) -> Option<Cow<Path>> {
+    pub fn callback_dependency_path(&self) -> Option<Cow<'_, Path>> {
         self.callback_dependency
             .as_ref()
             .map(|p| self.concatenate_with_out_path(p))
     }
 
-    pub fn message_take_to_callback_latency_path(&self) -> Option<Cow<Path>> {
+    pub fn message_take_to_callback_latency_path(&self) -> Option<Cow<'_, Path>> {
         self.message_take_to_callback_latency
             .as_ref()
             .map(|p| self.concatenate_with_out_path(p))
     }
 
-    pub fn utilization_path(&self) -> Option<Cow<Path>> {
+    pub fn utilization_path(&self) -> Option<Cow<'_, Path>> {
         self.utilization
             .as_ref()
             .map(|p| self.concatenate_with_out_path(p))
     }
 
-    pub fn real_utilization_path(&self) -> Option<Cow<Path>> {
+    pub fn real_utilization_path(&self) -> Option<Cow<'_, Path>> {
         self.real_utilization
             .as_ref()
             .map(|p| self.concatenate_with_out_path(p))
     }
 
-    pub fn spin_duration_path(&self) -> Option<Cow<Path>> {
+    pub fn spin_duration_path(&self) -> Option<Cow<'_, Path>> {
         self.spin_duration
             .as_ref()
             .map(|p| self.concatenate_with_out_path(p))

--- a/src/argsv2/mod.rs
+++ b/src/argsv2/mod.rs
@@ -50,6 +50,10 @@ impl Args {
 }
 
 #[derive(Debug, Subcommand, Clone, derive_more::Display)]
+#[allow(
+    clippy::large_enum_variant,
+    reason = "This enum is used as a singleton so only one instance should be constructed."
+)]
 pub enum TracerCommand {
     /// Analyze a ROS 2 trace and generate graphs, JSON or bundle outputs
     #[display("analyze")]

--- a/src/argsv2/mod.rs
+++ b/src/argsv2/mod.rs
@@ -20,7 +20,7 @@ pub struct Args {
 }
 
 impl Args {
-    pub fn get() -> &'static Args {
+    pub fn get() -> &'static Self {
         CLI_ARGS.get_or_init(Self::parse)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,15 @@
 #![forbid(unsafe_code, reason = "It shouldn't be needed")]
 
-mod analyses;
-mod argsv2;
-mod events_common;
-mod model;
-mod processed_events;
-mod processor;
-mod raw_events;
-mod statistics;
-mod utils;
-mod visualization;
+pub mod analyses;
+pub mod argsv2;
+pub mod events_common;
+pub mod model;
+pub mod processed_events;
+pub mod processor;
+pub mod raw_events;
+pub mod statistics;
+pub mod utils;
+pub mod visualization;
 
 use std::ffi::CString;
 

--- a/src/processor/error.rs
+++ b/src/processor/error.rs
@@ -212,13 +212,13 @@ impl AlreadyExists {
         event: &E,
         time: Time,
         context: &Context,
-    ) -> ProcessingEvent {
-        ProcessingEvent {
+    ) -> Box<ProcessingEvent> {
+        Box::new(ProcessingEvent {
             raw_event: raw_events::Event::from(event.clone().into()),
             timestamp: time,
             context: context.clone(),
             cause: self.into(),
-        }
+        })
     }
 }
 

--- a/src/raw_events/ros2.rs
+++ b/src/raw_events/ros2.rs
@@ -370,8 +370,8 @@ impl TryFrom<bt2_sys::field::BtFieldConst> for Gid {
         let array = value.try_into_array()?;
         let len = array.get_length() as usize;
         match len {
-            GID_SIZE_JAZZY => Ok(Gid::Jazzy(array.try_into()?)),
-            GID_SIZE_KILTED => Ok(Gid::Kilted(array.try_into()?)),
+            GID_SIZE_JAZZY => Ok(Self::Jazzy(array.try_into()?)),
+            GID_SIZE_KILTED => Ok(Self::Kilted(array.try_into()?)),
             _ => Err(ConversionError::User(GidConversionError(len).into())),
         }
     }

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -113,7 +113,7 @@ impl TryFrom<f64> for Quantile {
     type Error = QuantileConversionError;
 
     fn try_from(quantile: f64) -> Result<Self, Self::Error> {
-        Quantile::new(quantile)
+        Self::new(quantile)
     }
 }
 
@@ -121,9 +121,10 @@ impl FromStr for Quantile {
     type Err = QuantileStringConversionError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Quantile::new(s.parse().map_err(|e| {
-            QuantileStringConversionError::ParseFloatError(e, s.to_string())
-        })?)?)
+        let value: f64 = s
+            .parse()
+            .map_err(|e| QuantileStringConversionError::ParseFloatError(e, s.to_string()))?;
+        Ok(Self::new(value)?)
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -420,7 +420,7 @@ impl std::fmt::Display for DisplayLargeDuration {
 
         let mut value = self.0;
         let mut suffix = 0;
-        while suffix < SUFFIX.len() - 1 && value % FACTOR[suffix] == 0 {
+        while suffix < SUFFIX.len() - 1 && value.is_multiple_of(FACTOR[suffix]) {
             value /= FACTOR[suffix];
 
             suffix += 1;

--- a/src/visualization/mod.rs
+++ b/src/visualization/mod.rs
@@ -43,6 +43,12 @@ impl ColorGradient {
     }
 }
 
+impl Default for ColorGradient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub struct Color([u8; 4]);
 
 impl Display for Color {


### PR DESCRIPTION
This will reduce the compiler and Clippy warnings to a minimum, making it readable again.