### PR TITLE
test: Check that the graph contains expected nodes

### DIFF
--- a/test/test.bats
+++ b/test/test.bats
@@ -25,12 +25,21 @@ setup() {
 }
 
 teardown() {
-    trace_stop
+    # Ensure that tests don't leave trace sessions running.
+    if lttng list "$ROS_DISTRO-$BATS_TEST_NAME" >/dev/null 2>&1; then
+        trace_stop
+    fi
+    # Ensure that analysis is run in all tests. It should never crash.
     Ros2TraceAnalyzer analyze "$TRACE"
 }
 
 @test "talker listener" {
     timeout -p -s SIGINT 3s ros2 launch demo_nodes_cpp talker_listener_launch.xml
+    trace_stop
+    Ros2TraceAnalyzer analyze "$TRACE"
+    # Check that the graph contains our nodes
+    Ros2TraceAnalyzer extract graph | grep 'label="/talker"'
+    Ros2TraceAnalyzer extract graph | grep 'label="/listener"'
 }
 
 @test "add_two_ints service" {


### PR DESCRIPTION
I merged the `main` branch to `graphs` so that we can add tests for the graphing functionality. In this PR, I added the first simple test for the `extract` subcommand. Currently, this test fails (and has always failed) for rolling because the trace is empty. It needs to be investigated why (I can do it later).

However, the `add_two_ints service` test, which passes on the main branch fails on the `graphs` branch. So this is either caused by my incorrect resolution of a conflict between `main` and `graphs` branches, or it is caused by the "graphing" changes in this branch. @Pavel-Sedlacek can you look at that?

For completeness, the r2ta output is:
```
   [WARN  Ros2TraceAnalyzer::analyses::analysis::dependency_graph] Skipping edge PublicationInCallback: target ROS-node mapping missing for Publisher(ArcMutWrapper(Mutex { data: Publisher { rmw_handle: Known(832340992), rcl_handle: Unknown, rclcpp_handle: Unknown, rmw_gid: Known(Gid("010fbb2f8821b3bd00000000-00000103")), topic_name: Unknown, node: Unknown, queue_depth: Unknown, removed: false }, poisoned: false, .. }))
   The application panicked (crashed).
   Message:  no entry found for key
   Location: src/analyses/analysis/dependency_graph.rs:667
```