### PR TITLE
Plot sizes

### DIFF
--- a/src/plotting/error.rs
+++ b/src/plotting/error.rs
@@ -4,16 +4,6 @@
 /// of creating a plot of a variable for a specific node in the dependency graph
 #[derive(thiserror::Error, Debug)]
 pub enum PlotConstructionCommonError {
-    /// Plot size too small error
-    ///
-    /// The requested plot size is too small
-    #[error("The requested plot size '{0}x{1}' is too small")]
-    PlotSizeTooSmall(u32, u32),
-
-    /// Plot size aspect ratio error
-    #[error("The requested plot size ratio '{0}' is too small or too large")]
-    PlotSizeRatio(f32),
-
     /// Error reported by plotters during the construction of the plot
     #[error("Plot construction error")]
     ConstructionError(#[source] Box<dyn std::error::Error + Send + Sync>),

--- a/src/plotting/mod.rs
+++ b/src/plotting/mod.rs
@@ -25,7 +25,7 @@ pub fn render_plot(
     plot_request: &PlotRequest,
     output_format: PlotOutputFormat,
 ) -> Result<(), PlotConstructionCommonError> {
-    let spacing = PlotSpacing::try_from((plot_request.size.0, plot_request.size.1))?;
+    let spacing = PlotSpacing::from((plot_request.size.0, plot_request.size.1));
 
     let axis_description = resolve_axis_descriptors(plot_request.property, &plot_request.plot);
 
@@ -87,16 +87,15 @@ struct PlotSpacing {
     pub desc_size: i32,
 }
 
-impl TryFrom<(u32, u32)> for PlotSpacing {
-    type Error = PlotConstructionCommonError;
-
-    fn try_from(value: (u32, u32)) -> Result<Self, Self::Error> {
-        let aspect_ratio = value.0 as f32 / value.1 as f32;
-        if !(0.5..2.0).contains(&aspect_ratio) {
-            return Err(PlotConstructionCommonError::PlotSizeRatio(aspect_ratio));
-        }
-
-        Ok(match value {
+impl From<(u32, u32)> for PlotSpacing {
+    fn from(value: (u32, u32)) -> Self {
+        match value {
+            (..400, _) | (_, ..400) => PlotSpacing {
+                margin: [16; 4],
+                label_margin: [32, 0, 0, 32],
+                label_size: [12; 2],
+                desc_size: 14,
+            },
             (400..800, 400..800) => PlotSpacing {
                 margin: [16; 4],
                 label_margin: [48, 0, 0, 48],
@@ -109,12 +108,7 @@ impl TryFrom<(u32, u32)> for PlotSpacing {
                 label_size: [20; 2],
                 desc_size: 32,
             },
-            _ => {
-                return Err(PlotConstructionCommonError::PlotSizeTooSmall(
-                    value.0, value.1,
-                ));
-            }
-        })
+        }
     }
 }
 

--- a/src/plotting/plots/histogram.rs
+++ b/src/plotting/plots/histogram.rs
@@ -72,7 +72,7 @@ impl HistogramPlot {
         let scaled_axis = [
             axis_descriptor
                 .x
-                .scaled_axis_unit((x_range.1 - x_range.0) / 2),
+                .scaled_axis_unit(x_range.0 + (x_range.1 - x_range.0) / 2),
             // This has logarithmic scale so there is no reasonable unit to cover
             // the entire range. If this becomes a problem we can allow for formatting
             // individual ticks and display just the exponents
@@ -120,7 +120,7 @@ impl PlotData<Coords> for HistogramPlot {
     }
 }
 
-// This method selects a x axis range so that all ticks are placed
+// This method selects an x axis range so that all ticks are placed
 // on "nice" round numbers
 fn histogram_x_axis_alignment(min: i64, max: i64, data_bins: usize) -> (i64, (i64, i64)) {
     fn round_bin_width(value: f64) -> i64 {


### PR DESCRIPTION
This PR addresses two issues:

#20: Removes the PlotSizeTooSmall check along with all related validation logic. Responsibility for selecting an appropriate plot size is now entirely delegated to the user.

Part of #19: Fixes axis unit resolution. Units were previously derived from half of the data range instead of the actual midpoint value, which caused small ranges or sparse datasets to incorrectly prefer smaller units. The single value scatter plots still do not display ticks.