### PR TITLE
Histogram margin & Plot caption

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,9 @@ Options:
           
           [default: 800x600]
 
+      --include-title
+          
+
   -h, --help
           Print help (see a summary with '-h')
 ```

--- a/src/argsv2/extract_args.rs
+++ b/src/argsv2/extract_args.rs
@@ -86,7 +86,7 @@ impl ExtractPropertyArgs {
 )]
 pub enum AnalysisProperty {
     /// Callback execution durations
-    #[display("Callback execution time")]
+    #[display("Callback execution times")]
     CallbackDuration,
 
     /// Delays between callback or timer activations
@@ -94,7 +94,7 @@ pub enum AnalysisProperty {
     ActivationDelay,
 
     /// Delays between publisher publications
-    #[display("Delay between publication")]
+    #[display("Delay between publications")]
     PublicationDelay,
 
     /// Delays between subscriber messages
@@ -102,6 +102,6 @@ pub enum AnalysisProperty {
     MessageDelay,
 
     /// Latency of a communication channel
-    #[display("Message latency")]
+    #[display("Message latencies")]
     MessageLatency,
 }

--- a/src/argsv2/plot_args.rs
+++ b/src/argsv2/plot_args.rs
@@ -42,6 +42,9 @@ pub struct PlotRequest {
     })]
     pub size: (u32, u32),
 
+    #[clap(long, value_name = "TITLE")]
+    pub include_title: bool,
+
     /// The type of plot to render the data as
     #[command(subcommand)]
     pub plot: PlotVariants,

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -14,14 +14,14 @@ use crate::argsv2::extract_args::AnalysisProperty;
 use crate::utils::binary_sql_store::{BinarySQLStoreError, BinarySqlStore};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Display, Debug)]
-#[display("{node}::{interface}")]
+#[display("{node} {interface}")]
 pub struct RosInterfaceCompleteName {
     pub interface: String,
     pub node: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Display, Debug)]
-#[display("{source_node}-({topic})>{destination_node}")]
+#[display("{topic} ({source_node} → {destination_node})")]
 pub struct RosChannelCompleteName {
     pub source_node: String,
     pub destination_node: String,
@@ -70,7 +70,7 @@ pub fn extract_property(
     input: &Path,
     element_id: i64,
     property: &AnalysisProperty,
-) -> color_eyre::eyre::Result<PlottableData> {
+) -> color_eyre::eyre::Result<(String, PlottableData)> {
     let store = BinarySqlStore::open(input)?;
 
     let element_id = element_id as usize;
@@ -97,46 +97,50 @@ pub fn extract_property(
     }
 
     let plottable_data = match property {
-        AnalysisProperty::CallbackDuration => PlottableData::I64(
-            store
+        AnalysisProperty::CallbackDuration => {
+            let d = store
                 .get_by_id::<CallbackDurationExport>(element_id)
-                .map_err(DataExtractionError::SourceDataParseError)?
-                .callback_durations,
-        ),
-        AnalysisProperty::ActivationDelay => PlottableData::I64(
-            store
+                .map_err(DataExtractionError::SourceDataParseError)?;
+            (d.name.to_string(), PlottableData::I64(d.callback_durations))
+        }
+        AnalysisProperty::ActivationDelay => {
+            let d = store
                 .get_by_id::<ActivationDelayExport>(element_id)
-                .map_err(DataExtractionError::SourceDataParseError)?
-                .activation_delays,
-        ),
-        AnalysisProperty::PublicationDelay => PlottableData::I64(
-            store
+                .map_err(DataExtractionError::SourceDataParseError)?;
+            (d.name.to_string(), PlottableData::I64(d.activation_delays))
+        }
+        AnalysisProperty::PublicationDelay => {
+            let d = store
                 .get_by_id::<PublicationDelayExport>(element_id)
-                .map_err(DataExtractionError::SourceDataParseError)?
-                .publication_delays,
-        ),
-        AnalysisProperty::MessageDelay => PlottableData::I64(
-            store
+                .map_err(DataExtractionError::SourceDataParseError)?;
+            (d.name.to_string(), PlottableData::I64(d.publication_delays))
+        }
+        AnalysisProperty::MessageDelay => {
+            let d = store
                 .get_by_id::<MessagesDelayExport>(element_id)
-                .map_err(DataExtractionError::SourceDataParseError)?
-                .messages_delays,
-        ),
-        AnalysisProperty::MessageLatency => PlottableData::I64(
-            store
+                .map_err(DataExtractionError::SourceDataParseError)?;
+
+            (d.name.to_string(), PlottableData::I64(d.messages_delays))
+        }
+        AnalysisProperty::MessageLatency => {
+            let d = store
                 .get_by_id::<MessageLatencyExport>(element_id)
                 .map_err(|e| match e {
                     BinarySQLStoreError::NoResults => {
                         DataExtractionError::NoSuchElement(element_id)
                     }
                     _ => e.into(),
-                })?
-                .messages_latencies,
-        ),
+                })?;
+            (d.name.to_string(), PlottableData::I64(d.messages_latencies))
+        }
     };
 
-    let _ = plottable_data.assert_valid()?;
+    let _ = plottable_data.1.assert_valid()?;
 
-    Ok(plottable_data)
+    Ok((
+        format!("{} of: {}", property, &plottable_data.0),
+        plottable_data.1,
+    ))
 }
 
 impl PlottableData {

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -28,15 +28,25 @@ pub struct RosChannelCompleteName {
     pub topic: String,
 }
 
-pub enum PlottableData {
-    I64(Vec<i64>),
+#[derive(Debug)]
+pub struct PlottableData {
+    pub title: String,
+    pub data: Vec<i64>,
 }
 
 impl PlottableData {
+    fn new(property: &AnalysisProperty, title: String, data: Vec<i64>) -> Self {
+        PlottableData {
+            title: format!("{} of: {}", property, title),
+            data,
+        }
+    }
+
     fn assert_valid(&self) -> Result<(), DataExtractionError> {
-        match self {
-            PlottableData::I64(items) if items.len() == 0 => Err(DataExtractionError::EmptyData),
-            _ => Ok(()),
+        if self.data.len() == 0 {
+            Err(DataExtractionError::EmptyData)
+        } else {
+            Ok(())
         }
     }
 }
@@ -70,7 +80,7 @@ pub fn extract_property(
     input: &Path,
     element_id: i64,
     property: &AnalysisProperty,
-) -> color_eyre::eyre::Result<(String, PlottableData)> {
+) -> color_eyre::eyre::Result<PlottableData> {
     let store = BinarySqlStore::open(input)?;
 
     let element_id = element_id as usize;
@@ -101,26 +111,26 @@ pub fn extract_property(
             let d = store
                 .get_by_id::<CallbackDurationExport>(element_id)
                 .map_err(DataExtractionError::SourceDataParseError)?;
-            (d.name.to_string(), PlottableData::I64(d.callback_durations))
+            PlottableData::new(property, d.name.to_string(), d.callback_durations)
         }
         AnalysisProperty::ActivationDelay => {
             let d = store
                 .get_by_id::<ActivationDelayExport>(element_id)
                 .map_err(DataExtractionError::SourceDataParseError)?;
-            (d.name.to_string(), PlottableData::I64(d.activation_delays))
+            PlottableData::new(property, d.name.to_string(), d.activation_delays)
         }
         AnalysisProperty::PublicationDelay => {
             let d = store
                 .get_by_id::<PublicationDelayExport>(element_id)
                 .map_err(DataExtractionError::SourceDataParseError)?;
-            (d.name.to_string(), PlottableData::I64(d.publication_delays))
+            PlottableData::new(property, d.name.to_string(), d.publication_delays)
         }
         AnalysisProperty::MessageDelay => {
             let d = store
                 .get_by_id::<MessagesDelayExport>(element_id)
                 .map_err(DataExtractionError::SourceDataParseError)?;
 
-            (d.name.to_string(), PlottableData::I64(d.messages_delays))
+            PlottableData::new(property, d.name.to_string(), d.messages_delays)
         }
         AnalysisProperty::MessageLatency => {
             let d = store
@@ -131,25 +141,20 @@ pub fn extract_property(
                     }
                     _ => e.into(),
                 })?;
-            (d.name.to_string(), PlottableData::I64(d.messages_latencies))
+            PlottableData::new(property, d.name.to_string(), d.messages_latencies)
         }
     };
 
-    let _ = plottable_data.1.assert_valid()?;
+    let _ = plottable_data.assert_valid()?;
 
-    Ok((
-        format!("{} of: {}", property, &plottable_data.0),
-        plottable_data.1,
-    ))
+    Ok(plottable_data)
 }
 
 impl PlottableData {
     pub fn export(&self, output: &mut impl Write) -> color_eyre::eyre::Result<()> {
-        let data = match self {
-            PlottableData::I64(items) => serde_json::to_string(&items)?,
-        };
+        let json_string = serde_json::to_string(&self.data)?;
 
-        writeln!(output, "{data}")?;
+        writeln!(output, "{json_string}")?;
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,8 @@ fn run_extract(args: &ExtractArgs) -> color_eyre::eyre::Result<()> {
             writeln!(output, "{graph}")?;
         }
         argsv2::extract_args::ExtractContentArgs::Property(args) => {
-            let data = extract::extract_property(&source_file, args.element_id(), args.property())?;
+            let (_, data) =
+                extract::extract_property(&source_file, args.element_id(), args.property())?;
 
             data.export(&mut output)?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,8 +85,7 @@ fn run_extract(args: &ExtractArgs) -> color_eyre::eyre::Result<()> {
             writeln!(output, "{graph}")?;
         }
         argsv2::extract_args::ExtractContentArgs::Property(args) => {
-            let (_, data) =
-                extract::extract_property(&source_file, args.element_id(), args.property())?;
+            let data = extract::extract_property(&source_file, args.element_id(), args.property())?;
 
             data.export(&mut output)?;
         }

--- a/src/plotting/mod.rs
+++ b/src/plotting/mod.rs
@@ -21,7 +21,7 @@ mod plots;
 
 pub fn render_plot(
     output: &mut Box<dyn std::io::Write>,
-    plotting_data: PlottableData,
+    plotting_data: (String, PlottableData),
     plot_request: &PlotRequest,
     output_format: PlotOutputFormat,
 ) -> Result<(), PlotConstructionCommonError> {
@@ -37,6 +37,7 @@ pub fn render_plot(
                 plotting_data,
                 &plot_request.plot,
                 &spacing,
+                plot_request.include_title,
                 &axis_description,
             )?;
             output.write_all(out.as_bytes()).unwrap();
@@ -48,6 +49,7 @@ pub fn render_plot(
                 plotting_data,
                 &plot_request.plot,
                 &spacing,
+                plot_request.include_title,
                 &axis_description,
             )?;
 
@@ -85,6 +87,9 @@ struct PlotSpacing {
 
     /// Font size of the axis description
     pub desc_size: i32,
+
+    /// Font size of the title
+    title_size: i32,
 }
 
 impl TryFrom<(u32, u32)> for PlotSpacing {
@@ -102,12 +107,14 @@ impl TryFrom<(u32, u32)> for PlotSpacing {
                 label_margin: [48, 0, 0, 48],
                 label_size: [12; 2],
                 desc_size: 20,
+                title_size: 24,
             },
             (800.., _) | (_, 800..) => PlotSpacing {
                 margin: [32; 4],
                 label_margin: [82, 0, 0, 64],
                 label_size: [20; 2],
                 desc_size: 32,
+                title_size: 36,
             },
             _ => {
                 return Err(PlotConstructionCommonError::PlotSizeTooSmall(
@@ -156,9 +163,10 @@ fn label_axis<B: DrawingBackend, T: Copy>(
 
 fn draw_into_canvas<B: DrawingBackend>(
     canvas: B,
-    data: PlottableData,
+    data: (String, PlottableData),
     variant: &PlotVariants,
     spacing: &PlotSpacing,
+    include_title: bool,
     axis_description: &AxisDescriptors,
 ) -> Result<(), PlotConstructionError<B::ErrorType>> {
     let area = canvas.into_drawing_area();
@@ -175,9 +183,13 @@ fn draw_into_canvas<B: DrawingBackend>(
         .set_label_area_size(LabelAreaPosition::Right, spacing.label_margin[2])
         .set_label_area_size(LabelAreaPosition::Bottom, spacing.label_margin[3]);
 
+    if include_title {
+        plot.caption(&data.0, ("sans-serif", spacing.title_size));
+    }
+
     match &variant {
         PlotVariants::Histogram(histogram_data) => {
-            let histogram = HistogramPlot::new(histogram_data, data, axis_description);
+            let histogram = HistogramPlot::new(histogram_data, data.1, axis_description);
             label_axis(
                 histogram.draw_into(&mut plot)?,
                 histogram.scale_axis(),
@@ -186,7 +198,7 @@ fn draw_into_canvas<B: DrawingBackend>(
             )?;
         }
         PlotVariants::Scatter => {
-            let scatter = ScatterPlot::new(data, axis_description);
+            let scatter = ScatterPlot::new(data.1, axis_description);
             label_axis(
                 scatter.draw_into(&mut plot)?,
                 scatter.scale_axis(),

--- a/src/plotting/mod.rs
+++ b/src/plotting/mod.rs
@@ -118,24 +118,25 @@ impl TryFrom<(u32, u32)> for PlotSpacing {
     }
 }
 
-fn label_axis<B: DrawingBackend>(
+fn label_axis<B: DrawingBackend, T: Copy>(
     mut plot: ChartContext<
         '_,
         B,
         Cartesian2d<
-            impl Ranged<ValueType = i64> + ValueFormatter<i64>,
+            impl Ranged<ValueType = T> + ValueFormatter<T>,
             impl Ranged<ValueType = i64> + ValueFormatter<i64>,
         >,
     >,
     scaled_axis_descriptor: &[ScaledAxisDescriptor; 2],
     sizes: &PlotSpacing,
+    fmap: impl Fn(T) -> i64,
 ) -> Result<(), PlotConstructionError<B::ErrorType>> {
     plot.configure_mesh()
         .max_light_lines(1)
         .x_desc(scaled_axis_descriptor[0].name())
         .y_desc(scaled_axis_descriptor[1].name())
         .x_label_formatter(&|v| {
-            format!("{:.2}", scaled_axis_descriptor[0].convert(*v))
+            format!("{:.2}", scaled_axis_descriptor[0].convert(fmap(*v)))
                 .trim_end_matches('0')
                 .trim_end_matches('.')
                 .to_string()
@@ -181,11 +182,17 @@ fn draw_into_canvas<B: DrawingBackend>(
                 histogram.draw_into(&mut plot)?,
                 histogram.scale_axis(),
                 spacing,
+                |v| v as i64,
             )?;
         }
         PlotVariants::Scatter => {
             let scatter = ScatterPlot::new(data, axis_description);
-            label_axis(scatter.draw_into(&mut plot)?, scatter.scale_axis(), spacing)?;
+            label_axis(
+                scatter.draw_into(&mut plot)?,
+                scatter.scale_axis(),
+                spacing,
+                |v| v,
+            )?;
         }
     }
 

--- a/src/plotting/mod.rs
+++ b/src/plotting/mod.rs
@@ -21,7 +21,7 @@ mod plots;
 
 pub fn render_plot(
     output: &mut Box<dyn std::io::Write>,
-    plotting_data: (String, PlottableData),
+    plotting_data: PlottableData,
     plot_request: &PlotRequest,
     output_format: PlotOutputFormat,
 ) -> Result<(), PlotConstructionCommonError> {
@@ -163,7 +163,7 @@ fn label_axis<B: DrawingBackend, T: Copy>(
 
 fn draw_into_canvas<B: DrawingBackend>(
     canvas: B,
-    data: (String, PlottableData),
+    data: PlottableData,
     variant: &PlotVariants,
     spacing: &PlotSpacing,
     include_title: bool,
@@ -184,12 +184,12 @@ fn draw_into_canvas<B: DrawingBackend>(
         .set_label_area_size(LabelAreaPosition::Bottom, spacing.label_margin[3]);
 
     if include_title {
-        plot.caption(&data.0, ("sans-serif", spacing.title_size));
+        plot.caption(&data.title, ("sans-serif", spacing.title_size));
     }
 
     match &variant {
         PlotVariants::Histogram(histogram_data) => {
-            let histogram = HistogramPlot::new(histogram_data, data.1, axis_description);
+            let histogram = HistogramPlot::new(histogram_data, &data.data, axis_description);
             label_axis(
                 histogram.draw_into(&mut plot)?,
                 histogram.scale_axis(),
@@ -198,7 +198,7 @@ fn draw_into_canvas<B: DrawingBackend>(
             )?;
         }
         PlotVariants::Scatter => {
-            let scatter = ScatterPlot::new(data.1, axis_description);
+            let scatter = ScatterPlot::new(&data.data, axis_description);
             label_axis(
                 scatter.draw_into(&mut plot)?,
                 scatter.scale_axis(),

--- a/src/plotting/plots/histogram.rs
+++ b/src/plotting/plots/histogram.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use plotters::chart::{ChartBuilder, ChartContext};
-use plotters::coord::types::RangedCoordi64;
+use plotters::coord::types::RangedCoordf64;
 use plotters::prelude::{Cartesian2d, DrawingBackend, IntoLogRange, LogCoord, Rectangle};
 use plotters::style::Color;
 
@@ -90,7 +90,7 @@ impl HistogramPlot {
     }
 }
 
-type Coords = Cartesian2d<RangedCoordi64, LogCoord<i64>>;
+type Coords = Cartesian2d<RangedCoordf64, LogCoord<i64>>;
 impl PlotData<Coords> for HistogramPlot {
     fn draw_into<'a, B: DrawingBackend>(
         &self,
@@ -98,17 +98,22 @@ impl PlotData<Coords> for HistogramPlot {
     ) -> Result<ChartContext<'a, B, Coords>, PlotConstructionError<B::ErrorType>> {
         let mut context = canvas
             .build_cartesian_2d(
-                self.x_range.0..self.x_range.1,
+                (self.x_range.0 as f64)..(self.x_range.1 as f64),
                 (self.y_range.0..self.y_range.1).log_scale(),
             )
             .map_err(PlotConstructionError::InvalidCoordinateSystem)?;
 
+        let margin = self.bin_width as f64 * 0.05;
+
         context
             .draw_series(self.data.iter().enumerate().map(|(b, size)| {
-                let x0 = self.x_range.0 + (b as u64 * self.bin_width) as i64;
-                let x1 = x0 + self.bin_width as i64;
+                let x0 = (self.x_range.0 + (b as u64 * self.bin_width) as i64) as f64;
+                let x1 = x0 + self.bin_width as f64;
 
-                Rectangle::new([(x0, *size), (x1, 0)], plotters::style::BLUE.filled())
+                Rectangle::new(
+                    [(x0 + margin, *size), (x1 - margin, 0)],
+                    plotters::style::BLUE.filled(),
+                )
             }))
             .map_err(PlotConstructionError::PlotSeriesError)?;
 

--- a/src/plotting/plots/histogram.rs
+++ b/src/plotting/plots/histogram.rs
@@ -22,11 +22,9 @@ pub struct HistogramPlot {
 impl HistogramPlot {
     pub fn new(
         histogram_data: &HistogramData,
-        data: PlottableData,
+        data: &[i64],
         axis_descriptor: &AxisDescriptors,
     ) -> Self {
-        let PlottableData::I64(data) = data;
-
         // How many bins the data should be split into (this is how many bins will actually render)
         let bin_count = if let Some(bins) = histogram_data.bins
             && bins != 0
@@ -59,7 +57,7 @@ impl HistogramPlot {
             .checked_sub(1)
             .expect("bin_count must be at least 1");
 
-        for d in &data {
+        for d in data {
             let bin = usize::try_from((d - min) / bin_width)
                 .unwrap()
                 .min(last_idx);

--- a/src/plotting/plots/scatter.rs
+++ b/src/plotting/plots/scatter.rs
@@ -16,9 +16,7 @@ pub struct ScatterPlot {
 }
 
 impl ScatterPlot {
-    pub fn new(data: PlottableData, axis_descriptors: &AxisDescriptors) -> Self {
-        let PlottableData::I64(data) = data;
-
+    pub fn new(data: &[i64], axis_descriptors: &AxisDescriptors) -> Self {
         let x_range = (0, data.len() as i64);
         let y_range = resolve_axis_range(&data);
 


### PR DESCRIPTION
This PR introduces a 10% margin (5% of the bin width on each side) between histogram bins to separate between adjacent bins with identical heights.

It also adds a CLI flag to enable plot captions. The caption is derived from the name stored in the results file for each graph element:
- Node: `/node element` (where element type can be e.g. `Callback(Subscriber(/topic))`)
- Edge: `/topic (/source_node -> /target_node)`