### PR TITLE
Plotting issues fix

### DIFF
--- a/src/argsv2/plot_args.rs
+++ b/src/argsv2/plot_args.rs
@@ -85,9 +85,11 @@ pub enum PlotVariants {
 }
 
 #[derive(Debug, Display, Args, Clone, Copy)]
-#[display("Histogram data {{ bins: {bins:?} }}")]
+#[display("Histogram data {{ scale: {scale:?} }}")]
 pub struct HistogramData {
-    /// Number of bins to split the data into
-    #[arg(long, short = 'b', value_name = "BINS")]
-    pub bins: Option<usize>,
+    /// Scale controls the number of bins the data is split into
+    ///
+    /// The actual bin count is always a multiple of 4
+    #[arg(long, short = 's', value_name = "SCALE")]
+    pub scale: Option<usize>,
 }

--- a/src/plotting/plots/histogram.rs
+++ b/src/plotting/plots/histogram.rs
@@ -27,8 +27,7 @@ impl HistogramPlot {
     ) -> Self {
         let PlottableData::I64(data) = data;
 
-        // How many bins the data should be split into (this is how many bins will actually render)
-        let bin_count = if let Some(bins) = histogram_data.bins
+        let min_bin_count = if let Some(bins) = histogram_data.scale
             && bins != 0
         {
             bins
@@ -48,11 +47,12 @@ impl HistogramPlot {
         };
 
         let (bin_width, x_range) = if data.len() > 1 {
-            histogram_x_axis_alignment(min, max, bin_count)
+            histogram_x_axis_alignment(min, max, min_bin_count)
         } else {
             // This is an explicit case when there is only one data point
             (1, (min, min + 1))
         };
+        let bin_count = ((x_range.1 - x_range.0) / bin_width) as usize;
 
         let mut binned_data = vec![0; bin_count];
         let last_idx = bin_count
@@ -60,7 +60,7 @@ impl HistogramPlot {
             .expect("bin_count must be at least 1");
 
         for d in &data {
-            let bin = usize::try_from((d - min) / bin_width)
+            let bin = usize::try_from((d - x_range.0) / bin_width)
                 .unwrap()
                 .min(last_idx);
 

--- a/src/plotting/plots/scatter.rs
+++ b/src/plotting/plots/scatter.rs
@@ -23,8 +23,12 @@ impl ScatterPlot {
         let y_range = resolve_axis_range(&data);
 
         let scaled_axis = [
-            axis_descriptors.x.scaled_axis_unit(x_range.1),
-            axis_descriptors.y.scaled_axis_unit(y_range.1),
+            axis_descriptors
+                .x
+                .scaled_axis_unit((x_range.1 - x_range.0) / 2),
+            axis_descriptors
+                .y
+                .scaled_axis_unit((y_range.1 - y_range.0) / 2),
         ];
 
         ScatterPlot {


### PR DESCRIPTION
There were three issues with plotting:

1. The bin flag does not control the number of bins. The value is adjusted to produce cleaner labels, so it would be better to rename it to scale.

2. The binning assumes the x-axis only increases to the right, which is only true for datasets that include zero. This can cause incorrect bin offsets.

3. The scatter plot did not resolve unit names properly, resulting in unclear labels. It now behaves the same as histograms.