### PR TITLE
Sorted graphviz output

### DIFF
--- a/src/analyses/analysis/dependency_graph.rs
+++ b/src/analyses/analysis/dependency_graph.rs
@@ -1,8 +1,10 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
 use std::ops::Not;
 use std::sync::{Arc, Mutex};
 
-use crate::analysis::utils::DisplayDurationStats;
+use itertools::Itertools;
+
 use crate::argsv2::extract_args::AnalysisProperty;
 use crate::events_common::Context;
 use crate::extract::{RosChannelCompleteName, RosInterfaceCompleteName};
@@ -13,7 +15,7 @@ use crate::model::{
 };
 use crate::processed_events::{Event, FullEvent, r2r, ros2};
 use crate::statistics::Sorted;
-use crate::utils::{DisplayDuration, Known, WeakKnown};
+use crate::utils::{ArcWeak, DisplayDuration, Known, WeakKnown};
 use crate::visualization::COLOR_GRADIENT;
 use crate::visualization::graphviz_export::{self, NodeShape};
 
@@ -923,12 +925,30 @@ pub struct DotGraph {
 
 impl DotGraph {
     pub fn new(graph: &DependencyGraph, color: bool, thickness: bool, min_multiplier: f64) -> Self {
+        fn element_name(node: Option<ArcWeak<Mutex<model::Node>>>, topic: impl Debug) -> String {
+            format!(
+                "{}{:?}",
+                node.map(|n| n
+                    .get_arc()
+                    .unwrap()
+                    .lock()
+                    .unwrap()
+                    .get_full_name()
+                    .to_string())
+                    .unwrap_or(String::new()),
+                topic
+            )
+        }
+
         let mut graph_node_to_ros_node: HashMap<Node, ArcMutWrapper<model::Node>> = HashMap::new();
         let mut node_to_id = HashMap::new();
 
         let mut graph_node_id = 1;
 
-        for publisher in graph.publisher_nodes.keys() {
+        for publisher in graph.publisher_nodes.keys().sorted_by_cached_key(|k| {
+            let v = k.0.lock().unwrap();
+            element_name(v.get_node().into(), v.get_topic())
+        }) {
             let node = Node::Publisher(publisher.clone());
             node_to_id.insert(node.clone(), graph_node_id);
             graph_node_id += 1;
@@ -940,7 +960,10 @@ impl DotGraph {
             }
         }
 
-        for subscriber in graph.subscriber_nodes.keys() {
+        for subscriber in graph.subscriber_nodes.keys().sorted_by_cached_key(|k| {
+            let v = k.0.lock().unwrap();
+            element_name(v.get_node().into(), v.get_topic())
+        }) {
             let node = Node::Subscriber(subscriber.clone());
             node_to_id.insert(node.clone(), graph_node_id);
             graph_node_id += 1;
@@ -952,7 +975,10 @@ impl DotGraph {
             }
         }
 
-        for timer in graph.timer_nodes.keys() {
+        for timer in graph.timer_nodes.keys().sorted_by_cached_key(|k| {
+            let v = k.0.lock().unwrap();
+            element_name(v.get_node().into(), v.get_period())
+        }) {
             let node = Node::Timer(timer.clone());
             node_to_id.insert(node.clone(), graph_node_id);
             graph_node_id += 1;
@@ -962,7 +988,10 @@ impl DotGraph {
             graph_node_to_ros_node.insert(node, ros_node.clone().into());
         }
 
-        for callback in graph.callback_nodes.keys() {
+        for callback in graph.callback_nodes.keys().sorted_by_cached_key(|k| {
+            let v = k.0.lock().unwrap();
+            element_name(v.get_node(), v.get_name())
+        }) {
             let node = Node::Callback(callback.clone());
             node_to_id.insert(node.clone(), graph_node_id);
             graph_node_id += 1;
@@ -1057,7 +1086,9 @@ fn process_edges(
 
     let mut edge_id = 1;
 
-    for (edge, edge_data) in graph_edges {
+    for (edge, edge_data) in graph_edges.iter().sorted_by_cached_key(|e| {
+        (node_to_id[&e.0.source()] as u64) << 32 | node_to_id[&e.0.target()] as u64
+    }) {
         let latencies = Sorted::from_unsorted(&edge_data.latencies);
         let Some(median) = latencies.median().copied() else {
             log::warn!("Skipping edge without latency samples: {edge:?}");
@@ -1238,7 +1269,11 @@ impl std::fmt::Display for DotGraph {
             .collect::<Vec<_>>();
 
         let mut clusters = vec![Vec::new(); self.ros_node_to_id.len()];
-        for (node, ros_node) in &self.graph_node_to_ros_node {
+        for (node, ros_node) in self
+            .graph_node_to_ros_node
+            .iter()
+            .sorted_by_cached_key(|v| v.1.0.lock().unwrap().get_full_name().to_string())
+        {
             let Some(id) = self.ros_node_to_id.get(ros_node).copied() else {
                 log::warn!(
                     "Skipping cluster placement due to missing ROS-node id for node {node:?}"
@@ -1256,18 +1291,7 @@ impl std::fmt::Display for DotGraph {
 
         let mut graph = graphviz_export::Graph::new();
         graph.set_attribute("rankdir", "LR");
-        for (node, id) in &self.node_to_id {
-            let ros_node_name =
-                self.graph_node_to_ros_node
-                    .get(node)
-                    .map_or(Known::Unknown, |node_arc| {
-                        node_arc
-                            .0
-                            .lock()
-                            .unwrap()
-                            .get_full_name()
-                            .map(ToString::to_string)
-                    });
+        for (node, id) in self.node_to_id.iter().sorted_by_key(|&(_, v)| v) {
             let node_name = get_node_name(node);
 
             let graph_node = graph.add_node(&node_name, *id);
@@ -1330,7 +1354,11 @@ impl std::fmt::Display for DotGraph {
             }
         }
 
-        for (cluster_nodes, cluster_name) in clusters.into_iter().zip(cluster_names) {
+        for (cluster_nodes, cluster_name) in clusters
+            .into_iter()
+            .zip(cluster_names)
+            .sorted_by_cached_key(|v| v.1.to_owned())
+        {
             graph.add_cluster(&cluster_name, cluster_nodes);
         }
 

--- a/src/visualization/graphviz_export.rs
+++ b/src/visualization/graphviz_export.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::fmt::Display;
 
 use derive_more::derive::Display;
+use itertools::Itertools;
 
 #[derive(Debug, Clone, Default)]
 pub struct Graph {
@@ -185,7 +186,7 @@ impl Attributes {
 
 impl Display for Attributes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut iter = self.attributes.iter();
+        let mut iter = self.attributes.iter().sorted_by_cached_key(|v| v.0);
         // Write value with Debug to escape special characters
         write!(f, "[")?;
         if let Some((key, value)) = iter.next() {


### PR DESCRIPTION
This PR changes the Graphviz output so that it stays consistent across multiple analyses of the same application by sorting nodes, edges, clusters and attributes

Two traces of the same application should produce identical DOT graphs, and should therefore be drawn in the same way.

- Nodes are sorted: `Type > RosNode > Topic/Duration/Name`
- Edges are sorted: `SourceNodeId > TargetNodeId`
- Clusters are sorted by Ros Node name
- Attributes are sorted by name