### PR TITLE
Dependency graph fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,7 @@ dependencies = [
  "num-traits",
  "phf",
  "serde",
+ "uncased",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0.214", features = ["derive"] }
 log = "0.4.22"
 env_logger = "0.11.5"
 clap-verbosity-flag = "3.0.4"
-colorgrad = "0.8.0"
+colorgrad = { version = "0.8.0", features = ["named-colors"] }
 serde_json = "1.0.133"
 postcard = { version = "1.1.3", features = [ "alloc" ] }
 rusqlite = "0.39.0"

--- a/src/analyses/mod.rs
+++ b/src/analyses/mod.rs
@@ -101,7 +101,11 @@ impl Analyses {
             if let Some(graph_analysis) = &self.dependency_graph {
                 let mut store = BinarySqlStore::new(&path)?;
 
-                let dot_graph = graph_analysis.to_dot_graph(false, false, 1.0);
+                let dot_graph = graph_analysis.to_dot_graph(
+                    args.color(),
+                    args.thickness(),
+                    args.min_multiplier(),
+                );
 
                 store.insert(&[crate::utils::binary_sql_store::DependencyGraph {
                     graph: dot_graph.to_string(),


### PR DESCRIPTION
At some point during the implementation of the unified results output, the arguments passed to the `to_dot_graph` function have been changed to `false`. This caused `color` and `thickness` flags to do nothing. Also, `colorgrad` removed `named-colors` from default features in `0.8.0`