### PR TITLE
Fix runtime errors caused by missing nodes

### DIFF
--- a/src/analyses/analysis/dependency_graph.rs
+++ b/src/analyses/analysis/dependency_graph.rs
@@ -289,6 +289,13 @@ impl DependencyGraph {
                     Edge::ServiceCallbackInvocation(service_arc.clone().into(), callback_arc);
                 let edge_data = self.edges.entry(edge).or_default();
 
+                let service = service_arc.lock().unwrap();
+                if service.get_node().is_unknown() {
+                    return;
+                }
+
+                drop(service);
+
                 if let Some(previous_activation) = edge_data.last_activation.replace(event_time) {
                     debug_assert_eq!(
                         edge_data.activation_delay.len() + 1,
@@ -304,11 +311,9 @@ impl DependencyGraph {
                 }
 
                 let service = service_arc.lock().unwrap();
-                let node_arc = service
-                    .get_node()
-                    .expect("Service should be associated with a node when invoked.")
-                    .get_arc()
-                    .expect("Node should be alive.");
+
+                let node_arc = service.get_node().unwrap().get_arc().unwrap();
+
                 let latency = self
                     .last_spin_wake_up_time_for_node
                     .get(&node_arc.into())
@@ -406,6 +411,9 @@ impl DependencyGraph {
             return;
         }
         let message = event.message.lock().unwrap();
+        if message.get_subscriber().is_none() {
+            return;
+        }
         let subscriber_arc = message.get_subscriber().unwrap();
         let subscriber_node = self
             .subscriber_nodes
@@ -462,6 +470,9 @@ impl DependencyGraph {
         context: &Context,
     ) {
         let publication = event.message.lock().unwrap();
+        if publication.get_publisher().is_none() {
+            return;
+        }
         let publisher_arc = publication.get_publisher().unwrap();
 
         let publisher_node = self
@@ -968,6 +979,9 @@ impl DotGraph {
             graph_node_id += 1;
 
             let callback = callback.0.lock().unwrap();
+            if callback.get_node().is_none() {
+                continue;
+            }
             let ros_node = callback.get_node().unwrap().get_arc().unwrap();
             graph_node_to_ros_node.insert(node, ros_node.clone().into());
         }
@@ -1058,11 +1072,6 @@ fn process_edges(
     let mut edge_id = 1;
 
     for (edge, edge_data) in graph_edges {
-        let latencies = Sorted::from_unsorted(&edge_data.latencies);
-        let Some(median) = latencies.median().copied() else {
-            log::warn!("Skipping edge without latency samples: {edge:?}");
-            continue;
-        };
         let edge_type = edge.as_type();
 
         let source = edge.source();
@@ -1088,6 +1097,12 @@ fn process_edges(
             log::warn!(
                 "Skipping edge {edge_type:?}: target ROS-node mapping missing for {target:?}"
             );
+            continue;
+        };
+
+        let latencies = Sorted::from_unsorted(&edge_data.latencies);
+        let Some(median) = latencies.median().copied() else {
+            log::warn!("Skipping edge without latency samples: {edge:?}");
             continue;
         };
 

--- a/src/processor/ros2.rs
+++ b/src/processor/ros2.rs
@@ -538,12 +538,19 @@ impl Processor {
         context_id: ContextId,
         context: &Context,
     ) -> Result<processed_events::ros2::RmwTake> {
-        let subscriber = self
-            .subscribers_by_rmw
-            .get_or_err(
-                event.rmw_subscription_handle.into_id(context_id),
-                "rmw_handle",
-            )
+        let subscriber = self.subscribers_by_rmw.get_or_err(
+            event.rmw_subscription_handle.into_id(context_id),
+            "rmw_handle",
+        );
+
+        if subscriber.is_err() {
+            return Ok(processed_events::ros2::RmwTake {
+                message: Arc::new(Mutex::new(SubscriptionMessage::new(event.message))),
+                taken: event.taken,
+            });
+        }
+
+        let subscriber = subscriber
             .map_err(|e| e.with_ros2_event(event, time, context))
             .wrap_err("Taken message missing subscriber.")?;
         let topic = subscriber
@@ -879,7 +886,8 @@ impl Processor {
         let callback_arc =
             Callback::new_timer(event.callback, &timer_arc, context.hostname().to_owned());
 
-        self.callbacks_by_id
+        let _ = self
+            .callbacks_by_id
             .insert(event.callback.into_id(context_id), callback_arc.clone())
             .and_then(filter_out_removed_callers)
             .map_or(Ok(()), |old: Arc<Mutex<Callback>>| {
@@ -887,7 +895,7 @@ impl Processor {
                     error::AlreadyExists::with_id(event.callback, &callback_arc, old)
                         .with_ros2_event(event, time, context),
                 )
-            })?;
+            });
 
         timer_arc
             .lock()


### PR DESCRIPTION
This is a temporary workaround rather than the proper fix, but most collected traces currently fail to process because of duplicate callback IDs and callbacks/services that are not associated with any node.